### PR TITLE
fix base when query string contains unescaped slashes

### DIFF
--- a/app-httpd.conf
+++ b/app-httpd.conf
@@ -12,7 +12,7 @@
     </Directory>
 
     RewriteEngine On
-    RewriteMap remapbase "prg:/bin/sed -u -e 's;[^ ]* ;;' -e 's; .*;;' -e 's;[^/]*;..;g' -e 's;../..;;' -e 's/.//' -e 's;^$;.;'"
+    RewriteMap remapbase "prg:/bin/sed -u -e 's;[^ ]* ;;' -e 's;[ ?].*;;' -e 's;[^/]*;..;g' -e 's;../..;;' -e 's/.//' -e 's;^$;.;'"
 
     RewriteCond /usr/local/apache2/htdocs/gridstudy%{REQUEST_URI} -f [OR]
     RewriteCond %{REQUEST_URI} ^/api/.* [OR]


### PR DESCRIPTION
This fixes urls like "http://foo.com/bar?url=http://other.com

In the query string, slashes and colon don't have to be escaped (although they can be).

Signed-off-by: Jon Harper <jon.harper87@gmail.com>