### PR TITLE
hackfix the initial silent login for azure

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -92,7 +92,14 @@ const App = () => {
         )
             .then((userManager) => {
                 setUserManager({ instance: userManager, error: null });
-                userManager.signinSilent();
+                userManager.signinSilent().catch(error => {
+                    const oidcHackReloaded = "gridsuite-oidc-hack-reloaded";
+                    if (!sessionStorage.getItem(oidcHackReloaded) && error.message === "authority mismatch on settings vs. signin state") {
+                        sessionStorage.setItem(oidcHackReloaded, true);
+                        console.log("Hack oidc, reload page to make login work");
+                        window.location.reload();
+                    }
+                });
             })
             .catch(function (error) {
                 setUserManager({ instance: null, error: error.message });


### PR DESCRIPTION
Reloading is mandatory because we don't know the issuer until we request the token, and we need to set the /common issuer first for the oidc-client-js library to request the token.