### PR TITLE
Remove spurious duplicate LoaderWithOverlay

### DIFF
--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -669,14 +669,6 @@ const StudyPane = (props) => {
 
         return (
             <div className={classes.main}>
-                {waitingLoadGeoData && (
-                    <LoaderWithOverlay
-                        color="inherit"
-                        loaderSize={70}
-                        isFixed={true}
-                        loadingMessageText="loadingGeoData"
-                    />
-                )}
                 <Drawer
                     variant={'persistent'}
                     className={classes.drawer}


### PR DESCRIPTION
regression from bad merge in 9257e44f572 reintrocing the overlay,
because it was moved in 83aa3a931a33de8

Signed-off-by: Jon Harper <jon.harper87@gmail.com>