### PR TITLE
Try to fix the map background not displaying anymore.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
         "production": [
             ">0.2%",
             "not dead",
-            "not op_mini all"
+            "not op_mini all",
+            "not chrome < 51",
+            "not safari < 10"
         ],
         "development": [
             "last 1 chrome version",


### PR DESCRIPTION
On the browser console we get
"An error occurred while parsing the WebWorker bundle. This is most likely due to improper transpilation by Babel; please see https://docs.mapbox.com/mapbox-gl-js/api/#transpiling-v2"

Apply the CRA solution from https://github.com/mapbox/mapbox-gl-js/issues/10565

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>