### PR TITLE
 Fix warning for NumericalField input type number props

### DIFF
--- a/src/components/network/equipment-table-editors.js
+++ b/src/components/network/equipment-table-editors.js
@@ -74,7 +74,8 @@ export const NumericalField = ({
                         fontSize: 'small',
                         flexGrow: 1,
                     },
-                    inputProps: { min: { min }, max: { max } },
+                    min: { min },
+                    max: { max },
                 }}
             />
         </Tooltip>


### PR DESCRIPTION
 Warning: React does not recognize the `inputProps` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `inputprops` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>