### PR TITLE
display empty panel when loading NAD

### DIFF
--- a/src/components/diagrams/networkAreaDiagram/network-area-diagram.js
+++ b/src/components/diagrams/networkAreaDiagram/network-area-diagram.js
@@ -345,8 +345,9 @@ const SizedNetworkAreaDiagram = (props) => {
         dispatch(fullScreenNetworkAreaDiagram(undefined));
     };
 
-    let sizeWidth = initialWidth,
-        sizeHeight = initialHeight;
+    let sizeWidth = initialWidth;
+    let sizeHeight = initialHeight;
+
     if (svg.error) {
         sizeWidth = errorWidth;
     } else if (

--- a/src/components/diagrams/networkAreaDiagram/network-area-diagram.js
+++ b/src/components/diagrams/networkAreaDiagram/network-area-diagram.js
@@ -52,6 +52,7 @@ const maxHeight = 650;
 const minWidth = 500;
 const minHeight = 400;
 const errorWidth = maxWidth;
+let initialWidth, initialHeight;
 
 const useStyles = makeStyles((theme) => ({
     divNad: {
@@ -344,15 +345,23 @@ const SizedNetworkAreaDiagram = (props) => {
         dispatch(fullScreenNetworkAreaDiagram(undefined));
     };
 
-    let sizeWidth, sizeHeight;
+    let sizeWidth = initialWidth,
+        sizeHeight = initialHeight;
     if (svg.error) {
-        sizeWidth = errorWidth; // height is not set so height is auto;
+        sizeWidth = errorWidth;
     } else if (
         typeof finalPaperWidth != 'undefined' &&
         typeof finalPaperHeight != 'undefined'
     ) {
         sizeWidth = finalPaperWidth;
         sizeHeight = finalPaperHeight;
+    }
+
+    if (sizeHeight !== undefined) {
+        initialHeight = sizeHeight;
+    }
+    if (sizeWidth !== undefined) {
+        initialWidth = sizeWidth;
     }
 
     return svg.error ? (


### PR DESCRIPTION
Display an empty panel when loading a new NAD (width and height are taken from the previous one). 
When the first NAD is loading, when opening a new study, we only display the header and the loader.