### PR TITLE
Fix(LoadModificationDialog): avoid returning an object as FormHelperText children

### DIFF
--- a/src/components/dialogs/load-modification-dialog.js
+++ b/src/components/dialogs/load-modification-dialog.js
@@ -126,7 +126,7 @@ const LoadModificationDialog = ({
         defaultValue: formValues?.loadType ? formValues.loadType.value : '',
         doTranslation: true,
         previousValue: loadInfos?.type
-            ? LOAD_TYPES.find((lt) => lt.id === loadInfos.type)
+            ? LOAD_TYPES.find((lt) => lt.id === loadInfos.type)?.label
             : undefined,
     });
 


### PR DESCRIPTION
it must be a string

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>