### PR TITLE
Fix MultiGrid warning

### DIFF
--- a/src/components/network/equipment-table.js
+++ b/src/components/network/equipment-table.js
@@ -100,12 +100,12 @@ export const EquipmentTable = (props) => {
                                 styleBottomLeftGrid={
                                     props.disableVerticalScroll
                                         ? { overflowY: 'hidden' }
-                                        : ''
+                                        : {}
                                 }
                                 styleBottomRightGrid={
                                     props.disableVerticalScroll
                                         ? { overflowY: 'hidden' }
-                                        : ''
+                                        : {}
                                 }
                             />
                         )}


### PR DESCRIPTION
Warning: Failed prop type: Invalid prop `styleBottomLeftGrid` of type `string` supplied to `MultiGrid`, expected `object`.

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>