### PR TITLE
Fix Nodes selection when inserting and removing nodes

### DIFF
--- a/src/components/graph/network-modification-tree-model.js
+++ b/src/components/graph/network-modification-tree-model.js
@@ -48,7 +48,20 @@ export default class NetworkModificationTreeModel {
                     type: 'smoothstep',
                 });
             });
-            this.treeElements = filteredTreeElements;
+
+            // fix old children nodes parentUuid when inserting new nodes
+            const nextTreeElements = filteredTreeElements.map((element) => {
+                // skip edges
+                if (newElement.childrenIds.includes(element.id)) {
+                    element.data = {
+                        ...element.data,
+                        parentNodeUuid: newElement.id,
+                    };
+                }
+                return element;
+            });
+
+            this.treeElements = nextTreeElements;
         }
         if (newElement.children) {
             newElement.children.forEach((child) => {
@@ -97,7 +110,24 @@ export default class NetworkModificationTreeModel {
                     });
                 });
             });
-            this.treeElements = filteredTreeElements;
+
+            // fix parentNodeUuid of children
+            const willbeDeletedNode = this.treeElements.find(
+                (el) => el.id === nodeId
+            );
+
+            const nextTreeElements = filteredTreeElements.map((element) => {
+                // skip edges
+                if (element.data?.parentNodeUuid === nodeId) {
+                    element.data = {
+                        ...element.data,
+                        parentNodeUuid: willbeDeletedNode.data?.parentNodeUuid,
+                    };
+                }
+                return element;
+            });
+
+            this.treeElements = nextTreeElements;
         });
     }
 


### PR DESCRIPTION
Edit AddChild to set children new parentNodeUuid when inserting, Edit RemoveNodes to set children new parentNodeUuid when removing between nodes.

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>