### PR TITLE
Fixes the bug preventing a SLD of an unbuilt node to be closed.

### DIFF
--- a/src/components/diagrams/singleLineDiagram/single-line-diagram-pane.js
+++ b/src/components/diagrams/singleLineDiagram/single-line-diagram-pane.js
@@ -285,7 +285,6 @@ export function SingleLineDiagramPane({
 
     // set single line diagram voltage level id, contained in url query parameters
     useEffect(() => {
-        if (disabled || !visible) return;
         // parse query parameter
         const queryParams = parse(location.search, {
             parseArrays: true,


### PR DESCRIPTION
When a SLD is open and the currentNode is not built, there was a bug that prevented the "close" icon of the SLD to close the SLD window.