### PR TITLE
Fix(SLD): avoid fetching SVG when "disabled" props when changing current node .

### DIFF
--- a/src/components/diagrams/singleLineDiagram/single-line-diagram-pane.js
+++ b/src/components/diagrams/singleLineDiagram/single-line-diagram-pane.js
@@ -27,6 +27,7 @@ import { Chip, Stack } from '@mui/material';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import makeStyles from '@mui/styles/makeStyles';
 import { getArray, useSingleLineDiagram, ViewState } from './utils';
+import { isNodeBuilt } from '../../graph/util/model-functions';
 
 function removeFromMap(oldMap, ids) {
     let removed = false;
@@ -278,10 +279,12 @@ export function SingleLineDiagramPane({
     );
 
     useEffect(() => {
-        if (!disabled && visible) {
+        // We use isNodeBuilt here instead of the "disabled" props to avoid
+        // triggering this effect when changing current node
+        if (isNodeBuilt(currentNodeRef.current) && visible) {
             setViews((oldVal) => oldVal.map(createView));
         }
-    }, [disabled, visible, createView]);
+    }, [visible, createView]);
 
     // set single line diagram voltage level id, contained in url query parameters
     useEffect(() => {

--- a/src/components/diagrams/singleLineDiagram/single-line-diagram.js
+++ b/src/components/diagrams/singleLineDiagram/single-line-diagram.js
@@ -56,6 +56,7 @@ import clsx from 'clsx';
 import AlertInvalidNode from '../../util/alert-invalid-node';
 import { useIsAnyNodeBuilding } from '../../util/is-any-node-building-hook';
 import Alert from '@mui/material/Alert';
+import { isNodeBuilt } from '../../graph/util/model-functions';
 
 export const SubstationLayout = {
     HORIZONTAL: 'horizontal',
@@ -279,6 +280,9 @@ const SizedSingleLineDiagram = forwardRef((props, ref) => {
 
     const theme = useTheme();
 
+    const currentNodeRef = useRef();
+    currentNodeRef.current = currentNode;
+
     const forceUpdate = useCallback(() => {
         updateState((s) => !s);
     }, []);
@@ -364,7 +368,9 @@ const SizedSingleLineDiagram = forwardRef((props, ref) => {
     ]);
 
     useEffect(() => {
-        if (props.svgUrl && !disabled) {
+        // We use isNodeBuilt here instead of the "disabled" props to avoid
+        // triggering this effect when changing current node
+        if (props.svgUrl && isNodeBuilt(currentNodeRef.current)) {
             updateLoadingState(true);
             fetchSvg(props.svgUrl)
                 .then((data) => {
@@ -390,7 +396,7 @@ const SizedSingleLineDiagram = forwardRef((props, ref) => {
         } else {
             setSvg(noSvg);
         }
-    }, [props.svgUrl, forceState, snackError, intlRef, disabled]);
+    }, [props.svgUrl, forceState, snackError, intlRef]);
 
     const { onNextVoltageLevelClick, onBreakerClick, isComputationRunning } =
         props;


### PR DESCRIPTION
Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>