### PR TITLE
Overloaded lines pane is now hidden when loadflow is not is 'success' state

### DIFF
--- a/src/components/network-map-tab.js
+++ b/src/components/network-map-tab.js
@@ -20,6 +20,7 @@ import { PARAM_DISPLAY_OVERLOAD_TABLE } from '../utils/config-params';
 import { getLineLoadingZone, LineLoadingZone } from './network/line-layer';
 import { useIntlRef } from '../utils/messages';
 import { isNodeBuilt } from './graph/util/model-functions';
+import { RunningStatus } from './util/running-status';
 
 const INITIAL_POSITION = [0, 0];
 
@@ -262,6 +263,10 @@ export const NetworkMapTab = ({
         return false;
     }, [network, lineFlowAlertThreshold]);
 
+    const isLoadFlowValid = () => {
+        return loadFlowStatus === RunningStatus.SUCCEED;
+    };
+
     const renderMap = () => (
         <NetworkMap
             network={network}
@@ -313,7 +318,7 @@ export const NetworkMapTab = ({
             {choiceVoltageLevelsSubstationId && renderVoltageLevelChoice()}
             {network?.substations?.length > 0 && renderNominalVoltageFilter()}
 
-            {displayOverloadTable && linesNearOverload() && (
+            {displayOverloadTable && isLoadFlowValid() && linesNearOverload() && (
                 <div className={classes.divOverloadedLineView}>
                     <OverloadedLinesView
                         lines={network.lines}


### PR DESCRIPTION
Signed-off-by: LE SAULNIER Kevin <kevin.lesaulnier@rte-france.com>