### PR TITLE
Ceil svg bbox values

### DIFF
--- a/src/components/diagrams/singleLineDiagram/single-line-diagram.js
+++ b/src/components/diagrams/singleLineDiagram/single-line-diagram.js
@@ -649,8 +649,8 @@ const SizedSingleLineDiagram = forwardRef((props, ref) => {
             const bbox = svgEl.getBBox();
             const xOrigin = bbox.x - 20;
             const yOrigin = bbox.y - 20;
-            const svgWidth = bbox.width + 40;
-            const svgHeight = bbox.height + 40;
+            const svgWidth = Math.ceil(bbox.width + 40);
+            const svgHeight = Math.ceil(bbox.height + 40);
 
             setSvgPreferredWidth(svgWidth);
             setSvgPreferredHeight(svgHeight);


### PR DESCRIPTION
This avoids the complexity of fractional pixels.

It should also help in almost all cases with crashes
caused by infinite rerendering because the preferred svg
width changes depending on the parent width
(because of rounding. For example in firefox:
set sizes 335.5198974609375 337.5198974609375
set sizes 335.5493469238281 337.5493469238281
set sizes 335.5407409667969 337.5407409667969
set sizes 335.5459289550781 337.5459289550781
set sizes 335.5407409667969 337.5407409667969
... crash
)

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>