### PR TITLE
Use commons-ui v0.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1553,9 +1553,9 @@
             "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw=="
         },
         "@gridsuite/commons-ui": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.23.0.tgz",
-            "integrity": "sha512-bHhtlIco8B9wY1HzfZe0vHgMKnedPaAPJ77hiMDqTr6NFv+UgCPW8lyCG+PqzRR/nQBVDgYtbrQsDX55oBKqRA==",
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.24.0.tgz",
+            "integrity": "sha512-dcoJXQKNtlxjZnfmrltAHiJe4cacdAPj2iI/qetC3furfVSZQBmplJAKSLWgrXYW6eAuzgIC6J9yOirhwPj1EA==",
             "requires": {
                 "@svgr/webpack": "^5.4.0",
                 "autosuggest-highlight": "^3.2.0",
@@ -4294,11 +4294,11 @@
             }
         },
         "autosuggest-highlight": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/autosuggest-highlight/-/autosuggest-highlight-3.2.1.tgz",
-            "integrity": "sha512-PZk89g6W6cyE+fbnWF2CCIUAmP55o5wceKVqqL6oosgvbWHKa2Mes6nRC/PGj7OwqBgIy65Nd21Dw3h6qodOmg==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/autosuggest-highlight/-/autosuggest-highlight-3.3.0.tgz",
+            "integrity": "sha512-Ogc+Ol7FdV6cE2bY4avVwcGDBav9MYTzfG2RGDMutjao4VQoZAOD8lZOATxjnjFXqJ3u7BFZIWcbbe0Hi78vAA==",
             "requires": {
-                "diacritic": "0.0.2"
+                "remove-accents": "^0.4.2"
             }
         },
         "axe-core": {
@@ -6522,11 +6522,6 @@
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
-        },
-        "diacritic": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/diacritic/-/diacritic-0.0.2.tgz",
-            "integrity": "sha512-iQCeDkSPwkfwWPr+HZZ49WRrM2FSI9097Q9w7agyRCdLcF9Eh2Ek0sHKcmMWx2oZVBjRBE/sziGFjZu0uf1Jbg=="
         },
         "diff-sequences": {
             "version": "26.6.2",
@@ -14614,6 +14609,11 @@
             "version": "0.2.7",
             "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
             "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+        },
+        "remove-accents": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+            "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
         },
         "remove-trailing-separator": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@emotion/react": "^11.8.2",
         "@emotion/styled": "^11.8.1",
-        "@gridsuite/commons-ui": "0.23.0",
+        "@gridsuite/commons-ui": "0.24.0",
         "@powsybl/diagram-viewer": "0.1.2",
         "@mui/icons-material": "^5.5.1",
         "@mui/lab": "^5.0.0-alpha.75",


### PR DESCRIPTION
It updates autosuggest-highlight dependency as expected but why it's not a peer dependency in commons-ui ?

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>