### PR TITLE
fix: Search equipment Infos with 3 chars doesn't work sometimes 

### DIFF
--- a/src/components/app-top-bar.js
+++ b/src/components/app-top-bar.js
@@ -170,7 +170,6 @@ const AppTopBar = ({ user, tabIndex, onChangeTab, userManager }) => {
 
     const searchMatchingEquipments = useCallback(
         (searchTerm) => {
-            if (lastSearchTermRef.current === searchTerm) return;
             lastSearchTermRef.current = searchTerm;
             fetchEquipmentsInfos(
                 studyUuid,

--- a/src/components/dialogs/equipment-search-dialog.js
+++ b/src/components/dialogs/equipment-search-dialog.js
@@ -54,7 +54,6 @@ const EquipmentSearchDialog = ({
 
     const searchMatchingEquipments = useCallback(
         (searchTerm) => {
-            if (lastSearchTermRef.current === searchTerm) return;
             lastSearchTermRef.current = searchTerm;
             fetchEquipmentsInfos(
                 studyUuid,


### PR DESCRIPTION
if searchTerm with 3 char then close and reopen the searchBar then with the same searchTerms it doesn't proc fetch

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>