### PR TITLE
Rename fetched* variables to *Promise for readiness 

### DIFF
--- a/src/components/dialogs/generator-creation-dialog.js
+++ b/src/components/dialogs/generator-creation-dialog.js
@@ -54,14 +54,14 @@ const useStyles = makeStyles((theme) => ({
  * Dialog to create a generator in the network
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
- * @param fetchedVoltageLevelOptions Promise handling list of voltage level options
+ * @param voltageLevelOptionsPromise Promise handling list of voltage level options
  * @param currentNodeUuid : the currently selected tree node
  * @param editData the data to edit
  */
 const GeneratorCreationDialog = ({
     open,
     onClose,
-    fetchedVoltageLevelOptions,
+    voltageLevelOptionsPromise,
     currentNodeUuid,
     editData,
 }) => {
@@ -230,7 +230,7 @@ const GeneratorCreationDialog = ({
     const [connectivity, connectivityField] = useConnectivityValue({
         label: 'Connectivity',
         inputForm: inputForm,
-        fetchedVoltageLevelOptions: fetchedVoltageLevelOptions,
+        voltageLevelOptionsPromise: voltageLevelOptionsPromise,
         currentNodeUuid: currentNodeUuid,
         voltageLevelIdDefaultValue: formValues?.voltageLevelId || null,
         busOrBusbarSectionIdDefaultValue:
@@ -373,8 +373,7 @@ GeneratorCreationDialog.propTypes = {
     editData: PropTypes.object,
     open: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    //promise
-    fetchedVoltageLevelOptions: PropTypes.shape({
+    voltageLevelOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),

--- a/src/components/dialogs/generator-modification-dialog.js
+++ b/src/components/dialogs/generator-modification-dialog.js
@@ -60,7 +60,7 @@ function getValueOrNull(val) {
  * @param {EventListener} onClose Event to close the dialog
  * @param voltageLevelOptions : the network voltageLevels available
  * @param currentNodeUuid : the currently selected tree node
- * @param fetchedEquipmentOptions the data generator option
+ * @param equipmentOptionsPromise Promise handling list of generator options
  * @param editData the data to edit
  */
 const GeneratorModificationDialog = ({
@@ -69,7 +69,7 @@ const GeneratorModificationDialog = ({
     onClose,
     voltageLevelOptions,
     currentNodeUuid,
-    fetchedEquipmentOptions,
+    equipmentOptionsPromise,
 }) => {
     const studyUuid = decodeURIComponent(useParams().studyUuid);
 
@@ -93,12 +93,12 @@ const GeneratorModificationDialog = ({
     };
 
     useEffect(() => {
-        if (!fetchedEquipmentOptions) return;
-        fetchedEquipmentOptions.then((values) => {
+        if (!equipmentOptionsPromise) return;
+        equipmentOptionsPromise.then((values) => {
             setEquipmentOptions(values);
             setLoadingEquipmentOptions(false);
         });
-    }, [fetchedEquipmentOptions]);
+    }, [equipmentOptionsPromise]);
 
     useEffect(() => {
         if (editData) {
@@ -368,8 +368,7 @@ GeneratorModificationDialog.propTypes = {
     onClose: PropTypes.func.isRequired,
     voltageLevelOptions: PropTypes.arrayOf(PropTypes.object),
     currentNodeUuid: PropTypes.string,
-    // Promise
-    fetchedEquipmentOptions: PropTypes.shape({
+    equipmentOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),

--- a/src/components/dialogs/input-hooks.js
+++ b/src/components/dialogs/input-hooks.js
@@ -258,7 +258,7 @@ export const useConnectivityValue = ({
     },
     disabled = false,
     inputForm,
-    fetchedVoltageLevelOptions,
+    voltageLevelOptionsPromise,
     currentNodeUuid,
     direction = 'row',
     voltageLevelIdDefaultValue,
@@ -284,14 +284,14 @@ export const useConnectivityValue = ({
     }, [inputForm.toggleClear]);
 
     useEffect(() => {
-        if (!fetchedVoltageLevelOptions) return;
+        if (!voltageLevelOptionsPromise) return;
 
-        fetchedVoltageLevelOptions.then((values) =>
+        voltageLevelOptionsPromise.then((values) =>
             setVoltageLevelOptions(
                 values.sort((a, b) => a.id.localeCompare(b.id))
             )
         );
-    }, [fetchedVoltageLevelOptions]);
+    }, [voltageLevelOptionsPromise]);
 
     useEffect(() => {
         if (!voltageLevelOptions) return;

--- a/src/components/dialogs/line-attach-to-voltage-level-dialog.js
+++ b/src/components/dialogs/line-attach-to-voltage-level-dialog.js
@@ -52,18 +52,18 @@ const getId = (e) => e?.id || (typeof e === 'string' ? e : '');
  * Dialog to attach a line to a (possibly new) voltage level.
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
- * @param fetchedLineOptions Promise handling list of network lines
+ * @param lineOptionsPromise Promise handling list of network lines
  * @param currentNodeUuid the currently selected tree node
- * @param fetchedSubstationOptions Promise handling list of network substations
+ * @param substationOptionsPromise Promise handling list of network substations
  * @param editData the possible line split with voltage level creation record to edit
  */
 const LineAttachToVoltageLevelDialog = ({
     open,
     onClose,
-    fetchedLineOptions,
+    lineOptionsPromise,
     voltageLevelOptions,
     currentNodeUuid,
-    fetchedSubstationOptions,
+    substationOptionsPromise,
     editData,
 }) => {
     const studyUuid = decodeURIComponent(useParams().studyUuid);
@@ -115,12 +115,12 @@ const LineAttachToVoltageLevelDialog = ({
     }, [editData]);
 
     useEffect(() => {
-        if (!fetchedLineOptions) return;
-        fetchedLineOptions.then((values) => {
+        if (!lineOptionsPromise) return;
+        lineOptionsPromise.then((values) => {
             setLineOptions(values);
             setLoadingLineOptions(false);
         });
-    }, [fetchedLineOptions]);
+    }, [lineOptionsPromise]);
 
     const extractDefaultVoltageLevelId = (fv) => {
         if (fv) {
@@ -579,7 +579,7 @@ const LineAttachToVoltageLevelDialog = ({
                         open={true}
                         onClose={onVoltageLevelDialogClose}
                         currentNodeUuid={currentNodeUuid}
-                        fetchedSubstationOptions={fetchedSubstationOptions}
+                        substationOptionsPromise={substationOptionsPromise}
                         onCreateVoltageLevel={onVoltageLevelDo}
                         editData={voltageLevelToEdit}
                     />
@@ -590,7 +590,7 @@ const LineAttachToVoltageLevelDialog = ({
                         onClose={onLineDialogClose}
                         voltageLevelOptions={voltageLevelOptions}
                         currentNodeUuid={currentNodeUuid}
-                        fetchedSubstationOptions={fetchedSubstationOptions}
+                        substationOptionsPromise={substationOptionsPromise}
                         displayConnectivity={false}
                         onCreateLine={onLineDo}
                         editData={lineToEdit}
@@ -606,13 +606,11 @@ LineAttachToVoltageLevelDialog.propTypes = {
     onClose: PropTypes.func.isRequired,
     lineOptions: PropTypes.arrayOf(PropTypes.object),
     currentNodeUuid: PropTypes.string,
-    // Promise
-    fetchedSubstationOptions: PropTypes.shape({
+    substationOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),
-    // Promise
-    fetchedLineOptions: PropTypes.shape({
+    lineOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),

--- a/src/components/dialogs/line-creation-dialog.js
+++ b/src/components/dialogs/line-creation-dialog.js
@@ -59,7 +59,7 @@ const useStyles = makeStyles((theme) => ({
  * Dialog to create a line in the network
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
- * @param fetchedVoltageLevelOptions Promise handling list of voltage level options
+ * @param voltageLevelOptionsPromise Promise handling list of voltage level options
  * @param currentNodeUuid : the node we are currently working on
  * @param editData the data to edit
  */
@@ -67,7 +67,7 @@ const LineCreationDialog = ({
     editData,
     open,
     onClose,
-    fetchedVoltageLevelOptions,
+    voltageLevelOptionsPromise,
     currentNodeUuid,
     onCreateLine = createLine,
     displayConnectivity = true,
@@ -206,7 +206,7 @@ const LineCreationDialog = ({
         id: 'Connectivity1',
         validation: { isFieldRequired: displayConnectivity },
         inputForm: inputForm,
-        fetchedVoltageLevelOptions: fetchedVoltageLevelOptions,
+        voltageLevelOptionsPromise: voltageLevelOptionsPromise,
         currentNodeUuid: currentNodeUuid,
         direction: 'column',
         voltageLevelIdDefaultValue: formValues?.voltageLevelId1 || null,
@@ -219,7 +219,7 @@ const LineCreationDialog = ({
         id: 'Connectivity2',
         validation: { isFieldRequired: displayConnectivity },
         inputForm: inputForm,
-        fetchedVoltageLevelOptions: fetchedVoltageLevelOptions,
+        voltageLevelOptionsPromise: voltageLevelOptionsPromise,
         currentNodeUuid: currentNodeUuid,
         direction: 'column',
         voltageLevelIdDefaultValue: formValues?.voltageLevelId2 || null,
@@ -456,8 +456,7 @@ LineCreationDialog.propTypes = {
     editData: PropTypes.object,
     open: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    //promise
-    fetchedVoltageLevelOptions: PropTypes.shape({
+    voltageLevelOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),

--- a/src/components/dialogs/line-split-with-voltage-level-dialog.js
+++ b/src/components/dialogs/line-split-with-voltage-level-dialog.js
@@ -47,18 +47,18 @@ const getId = (e) => e?.id || (typeof e === 'string' ? e : '');
  * Dialog to cut a line in two parts with in insertion of (possibly new) voltage level.
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
- * @param fetchedLineOptions Promise handling list of network lines
+ * @param lineOptionsPromise Promise handling list of network lines
  * @param currentNodeUuid the currently selected tree node
- * @param fetchedSubstationOptions Promise handling list of network substations
+ * @param substationOptionsPromise Promise handling list of network substations
  * @param editData the possible line split with voltage level creation record to edit
  */
 const LineSplitWithVoltageLevelDialog = ({
     open,
     onClose,
-    fetchedLineOptions,
+    lineOptionsPromise,
     voltageLevelOptions,
     currentNodeUuid,
-    fetchedSubstationOptions,
+    substationOptionsPromise,
     editData,
 }) => {
     const studyUuid = decodeURIComponent(useParams().studyUuid);
@@ -130,12 +130,12 @@ const LineSplitWithVoltageLevelDialog = ({
     }, [editData]);
 
     useEffect(() => {
-        if (!fetchedLineOptions) return;
-        fetchedLineOptions.then((values) => {
+        if (!lineOptionsPromise) return;
+        lineOptionsPromise.then((values) => {
             setLineOptions(values);
             setLoadingLineOptions(false);
         });
-    }, [fetchedLineOptions]);
+    }, [lineOptionsPromise]);
 
     const extractDefaultVoltageLevelId = (fv) => {
         if (fv) {
@@ -478,7 +478,7 @@ const LineSplitWithVoltageLevelDialog = ({
                         open={true}
                         onClose={onVoltageLevelDialogClose}
                         currentNodeUuid={currentNodeUuid}
-                        fetchedSubstationOptions={fetchedSubstationOptions}
+                        substationOptionsPromise={substationOptionsPromise}
                         onCreateVoltageLevel={onVoltageLevelDo}
                         editData={voltageLevelToEdit}
                     />
@@ -498,13 +498,11 @@ const LineSplitWithVoltageLevelDialog = ({
 LineSplitWithVoltageLevelDialog.propTypes = {
     open: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    // Promise
-    fetchedSubstationOptions: PropTypes.shape({
+    substationOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),
-    // Promise
-    fetchedLineOptions: PropTypes.shape({
+    lineOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),

--- a/src/components/dialogs/load-creation-dialog.js
+++ b/src/components/dialogs/load-creation-dialog.js
@@ -44,7 +44,7 @@ import { useFormSearchCopy } from './form-search-copy-hook';
  * Dialog to create a load in the network
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
- * @param fetchedVoltageLevelOptions Promise handling list of voltage level options
+ * @param voltageLevelOptionsPromise Promise handling list of voltage level options
  * @param currentNodeUuid : the node we are currently working on
  * @param editData the data to edit
  */
@@ -52,7 +52,7 @@ const LoadCreationDialog = ({
     editData,
     open,
     onClose,
-    fetchedVoltageLevelOptions,
+    voltageLevelOptionsPromise,
     currentNodeUuid,
 }) => {
     const studyUuid = decodeURIComponent(useParams().studyUuid);
@@ -153,7 +153,7 @@ const LoadCreationDialog = ({
     const [connectivity, connectivityField] = useConnectivityValue({
         label: 'Connectivity',
         inputForm: inputForm,
-        fetchedVoltageLevelOptions: fetchedVoltageLevelOptions,
+        voltageLevelOptionsPromise: voltageLevelOptionsPromise,
         currentNodeUuid: currentNodeUuid,
         voltageLevelIdDefaultValue: formValues?.voltageLevelId || null,
         busOrBusbarSectionIdDefaultValue:
@@ -261,8 +261,7 @@ LoadCreationDialog.propTypes = {
     editData: PropTypes.object,
     open: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    //promise
-    fetchedVoltageLevelOptions: PropTypes.shape({
+    voltageLevelOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),

--- a/src/components/dialogs/load-modification-dialog.js
+++ b/src/components/dialogs/load-modification-dialog.js
@@ -42,7 +42,7 @@ import {
  * Dialog to modify a load in the network
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
- * @param fetchedEquipmentOptions Promise handling list of loads that can be modified
+ * @param equipmentOptionsPromise Promise handling list of loads that can be modified
  * @param voltageLevelOptions : the network voltageLevels available
  * @param currentNodeUuid : the node we are currently working on
  * @param editData the data to edit
@@ -53,7 +53,7 @@ const LoadModificationDialog = ({
     onClose,
     voltageLevelOptions,
     currentNodeUuid,
-    fetchedEquipmentOptions,
+    equipmentOptionsPromise,
 }) => {
     const studyUuid = decodeURIComponent(useParams().studyUuid);
 
@@ -75,12 +75,12 @@ const LoadModificationDialog = ({
     };
 
     useEffect(() => {
-        if (!fetchedEquipmentOptions) return;
-        fetchedEquipmentOptions.then((values) => {
+        if (!equipmentOptionsPromise) return;
+        equipmentOptionsPromise.then((values) => {
             setEquipmentOptions(values);
             setLoadingEquipmentOptions(false);
         });
-    }, [fetchedEquipmentOptions]);
+    }, [equipmentOptionsPromise]);
 
     useEffect(() => {
         if (editData) {
@@ -250,8 +250,7 @@ LoadModificationDialog.propTypes = {
     onClose: PropTypes.func.isRequired,
     voltageLevelOptions: PropTypes.arrayOf(PropTypes.object),
     currentNodeUuid: PropTypes.string,
-    // Promise
-    fetchedEquipmentOptions: PropTypes.shape({
+    equipmentOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),

--- a/src/components/dialogs/shunt-compensator-creation-dialog.js
+++ b/src/components/dialogs/shunt-compensator-creation-dialog.js
@@ -45,14 +45,14 @@ const disabledChecked = { disabled: true };
  * Dialog to create a shunt compensator in the network
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
- * @param fetchedVoltageLevelOptions Promise handling list of voltage level options
+ * @param voltageLevelOptionsPromise Promise handling list of voltage level options
  * @param currentNodeUuid : the node we are currently working on
  * @param editData the data to edit
  */
 const ShuntCompensatorCreationDialog = ({
     open,
     onClose,
-    fetchedVoltageLevelOptions,
+    voltageLevelOptionsPromise,
     currentNodeUuid,
     editData,
 }) => {
@@ -166,7 +166,7 @@ const ShuntCompensatorCreationDialog = ({
     const [connectivity, connectivityField] = useConnectivityValue({
         label: 'Connectivity',
         inputForm: inputForm,
-        fetchedVoltageLevelOptions: fetchedVoltageLevelOptions,
+        voltageLevelOptionsPromise: voltageLevelOptionsPromise,
         currentNodeUuid: currentNodeUuid,
         voltageLevelIdDefaultValue: formValues?.voltageLevelId || null,
         busOrBusbarSectionIdDefaultValue:
@@ -274,8 +274,7 @@ ShuntCompensatorCreationDialog.propTypes = {
     editData: PropTypes.object,
     open: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    //promise
-    fetchedVoltageLevelOptions: PropTypes.shape({
+    voltageLevelOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),

--- a/src/components/dialogs/two-windings-transformer-creation-dialog.js
+++ b/src/components/dialogs/two-windings-transformer-creation-dialog.js
@@ -49,7 +49,7 @@ const useStyles = makeStyles((theme) => ({
  * Dialog to create a two windings transformer in the network
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
- * @param fetchedVoltageLevelOptions Promise handling list of voltage level options
+ * @param voltageLevelOptionsPromise Promise handling list of voltage level options
  * @param currentNodeUuid : the node we are currently working on
  * @param editData the data to edit
  */
@@ -57,7 +57,7 @@ const TwoWindingsTransformerCreationDialog = ({
     editData,
     open,
     onClose,
-    fetchedVoltageLevelOptions,
+    voltageLevelOptionsPromise,
     currentNodeUuid,
 }) => {
     const classes = useStyles();
@@ -189,7 +189,7 @@ const TwoWindingsTransformerCreationDialog = ({
         label: 'Connectivity',
         id: 'Connectivity1',
         inputForm: inputForm,
-        fetchedVoltageLevelOptions: fetchedVoltageLevelOptions,
+        voltageLevelOptionsPromise: voltageLevelOptionsPromise,
         currentNodeUuid: currentNodeUuid,
         direction: 'column',
         voltageLevelIdDefaultValue: formValues?.voltageLevelId1 || null,
@@ -201,7 +201,7 @@ const TwoWindingsTransformerCreationDialog = ({
         label: 'Connectivity',
         id: 'Connectivity2',
         inputForm: inputForm,
-        fetchedVoltageLevelOptions: fetchedVoltageLevelOptions,
+        voltageLevelOptionsPromise: voltageLevelOptionsPromise,
         currentNodeUuid: currentNodeUuid,
         direction: 'column',
         voltageLevelIdDefaultValue: formValues?.voltageLevelId2 || null,
@@ -373,8 +373,7 @@ TwoWindingsTransformerCreationDialog.propTypes = {
     editData: PropTypes.object,
     open: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    //promise
-    fetchedVoltageLevelOptions: PropTypes.shape({
+    voltageLevelOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),

--- a/src/components/dialogs/voltage-level-creation-dialog.js
+++ b/src/components/dialogs/voltage-level-creation-dialog.js
@@ -231,7 +231,7 @@ function validateConnection(values) {
  * Dialog to create a voltage level in the network
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
- * @param fetchedSubstationOptions Promise handling list of network substations
+ * @param substationOptionsPromise Promise handling list of network substations
  * @param currentNodeUuid the currently selected tree node
  * @param editData the data to edit
  * @param onCreateVoltageLevel callback when OK is triggered,
@@ -251,7 +251,7 @@ const VoltageLevelCreationDialog = ({
     editData,
     open,
     onClose,
-    fetchedSubstationOptions,
+    substationOptionsPromise,
     currentNodeUuid,
     onCreateVoltageLevel = createVoltageLevel,
 }) => {
@@ -308,12 +308,12 @@ const VoltageLevelCreationDialog = ({
     }, [editData]);
 
     useEffect(() => {
-        if (!fetchedSubstationOptions) return;
-        fetchedSubstationOptions.then((values) => {
+        if (!substationOptionsPromise) return;
+        substationOptionsPromise.then((values) => {
             setSubstationOptions(values);
             setLoadingSubstationOptions(false);
         });
-    }, [fetchedSubstationOptions]);
+    }, [substationOptionsPromise]);
 
     const [voltageLevelId, voltageLevelIdField] = useTextValue({
         label: 'ID',
@@ -488,8 +488,7 @@ VoltageLevelCreationDialog.propTypes = {
     editData: PropTypes.object,
     open: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    // Promise
-    fetchedSubstationOptions: PropTypes.shape({
+    substationOptionsPromise: PropTypes.shape({
         then: PropTypes.func.isRequired,
         catch: PropTypes.func.isRequired,
     }),

--- a/src/components/graph/menus/network-modification-node-editor.js
+++ b/src/components/graph/menus/network-modification-node-editor.js
@@ -176,42 +176,42 @@ const NetworkModificationNodeEditor = () => {
     }
 
     function withVLs(p) {
-        const fetchedVoltageLevelOptions = fetchVoltageLevels(
+        const voltageLevelOptionsPromise = fetchVoltageLevels(
             studyUuid,
             currentTreeNode?.id
         );
         return {
             ...p,
-            fetchedVoltageLevelOptions: fetchedVoltageLevelOptions,
+            voltageLevelOptionsPromise: voltageLevelOptionsPromise,
         };
     }
 
     function withLines(p) {
-        const fetchedLineOptions = fetchLines(
+        const lineOptionsPromise = fetchLines(
             studyUuid,
             currentTreeNode?.id,
             []
         );
         return {
             ...p,
-            fetchedLineOptions: fetchedLineOptions,
+            lineOptionsPromise: lineOptionsPromise,
         };
     }
 
     function withSubstations(p) {
-        const fetchedSubstationOptions = fetchSubstations(
+        const substationOptionsPromise = fetchSubstations(
             studyUuid,
             currentTreeNode?.id,
             []
         );
         return {
             ...p,
-            fetchedSubstationOptions: fetchedSubstationOptions,
+            substationOptionsPromise: substationOptionsPromise,
         };
     }
 
     function withEquipmentModificationOptions(Dialog, resourceType, resource) {
-        const fetchedEquipmentOptions = fetchEquipments(
+        const equipmentOptionsPromise = fetchEquipments(
             studyUuid,
             currentTreeNode?.id,
             [],
@@ -223,7 +223,7 @@ const NetworkModificationNodeEditor = () => {
         function withFetchedOptions(p) {
             return {
                 ...p,
-                fetchedEquipmentOptions: fetchedEquipmentOptions,
+                equipmentOptionsPromise: equipmentOptionsPromise,
             };
         }
 


### PR DESCRIPTION
when passing Promise as props for hypothesis dialogs.

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>