### PR TITLE
Force edited row on top of table

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "deck.gl": "^8.0.0",
         "geolib": "^3.2.1",
         "localized-countries": "^2.0.0",
-        "lodash": "^4.17.21",
         "lucene-escape-query": "^1.0.1",
         "mui-nested-menu": "^2.0.0",
         "memoize-one": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "deck.gl": "^8.0.0",
         "geolib": "^3.2.1",
         "localized-countries": "^2.0.0",
+        "lodash": "^4.17.21",
         "lucene-escape-query": "^1.0.1",
         "mui-nested-menu": "^2.0.0",
         "memoize-one": "^5.1.1",

--- a/src/components/network/equipment-table.js
+++ b/src/components/network/equipment-table.js
@@ -57,7 +57,8 @@ export const EquipmentTable = (props) => {
                     cell,
                     columnDefinition,
                     key,
-                    style
+                    style,
+                    rowIndex
                 );
             } else {
                 return (
@@ -111,7 +112,7 @@ export const EquipmentTable = (props) => {
                                 ref={gridRef}
                                 cellRenderer={cellRenderer}
                                 fixedColumnCount={fixedColumnsCount}
-                                fixedRowCount={props.showEditRow ? 2 : 1}
+                                fixedRowCount={props.showEditRow ? 2 : 1} // 1 for the header, 2 if there is a line in edit mode just under the header
                                 height={height}
                                 width={width}
                                 columnCount={props.columns.length}

--- a/src/components/network/equipment-table.js
+++ b/src/components/network/equipment-table.js
@@ -111,7 +111,7 @@ export const EquipmentTable = (props) => {
                                 ref={gridRef}
                                 cellRenderer={cellRenderer}
                                 fixedColumnCount={fixedColumnsCount}
-                                fixedRowCount={1}
+                                fixedRowCount={props.showEditRow ? 2 : 1}
                                 height={height}
                                 width={width}
                                 columnCount={props.columns.length}
@@ -124,16 +124,6 @@ export const EquipmentTable = (props) => {
                                 enableFixedRowScroll={true}
                                 hideTopRightGridScrollbar={true}
                                 hideBottomLeftGridScrollbar={true}
-                                styleBottomLeftGrid={
-                                    props.disableVerticalScroll
-                                        ? { overflowY: 'hidden' }
-                                        : {}
-                                }
-                                styleBottomRightGrid={
-                                    props.disableVerticalScroll
-                                        ? { overflowY: 'hidden' }
-                                        : {}
-                                }
                                 onScrollbarPresenceChange={(scrollBars) => {
                                     setVerticalScrollbarPresence(
                                         scrollBars?.vertical

--- a/src/components/network/network-table.js
+++ b/src/components/network/network-table.js
@@ -447,16 +447,7 @@ const NetworkTable = (props) => {
                 // When modifying a row, a shallow copy of the edited row is created and put on top of the table.
                 // The edition is then done on the copy, on top of the table, and not below, to prevent
                 // bugs of rows changing position in the middle of modifications.
-                let editRowPosition;
-                for (
-                    editRowPosition = 0;
-                    editRowPosition < result.length;
-                    editRowPosition++
-                ) {
-                    if (isLineOnEditMode(result[editRowPosition])) {
-                        return [result[editRowPosition], ...result];
-                    }
-                }
+                return [result[parseInt(lineEdit.rowIndex) - 1], ...result];
             }
             return result;
         },
@@ -467,8 +458,8 @@ const NetworkTable = (props) => {
             filter,
             formatCell,
             props.disabled,
-            isLineOnEditMode,
             isModifyingRow,
+            lineEdit,
         ]
     );
 
@@ -813,6 +804,7 @@ const NetworkTable = (props) => {
                                         oldValues: {},
                                         newValues: {},
                                         id: rowData.id,
+                                        rowIndex: rowIndex,
                                         errors: new Map(),
                                         equipmentType:
                                             TABLES_DEFINITION_INDEXES.get(
@@ -1015,36 +1007,35 @@ const NetworkTable = (props) => {
         (rowData, columnDefinition, key, style, rowIndex) => {
             if (
                 isLineOnEditMode(rowData) &&
-                rowData[columnDefinition.dataKey] !== undefined
+                rowData[columnDefinition.dataKey] !== undefined &&
+                rowIndex === 1
             ) {
-                if (rowIndex === 1) {
-                    // when we edit a numeric field, we display the original un-rounded value
-                    const currentValue = columnDefinition.numeric
-                        ? rowData[columnDefinition.dataKey]
-                        : formatCell(rowData, columnDefinition).value;
+                // when we edit a numeric field, we display the original un-rounded value
+                const currentValue = columnDefinition.numeric
+                    ? rowData[columnDefinition.dataKey]
+                    : formatCell(rowData, columnDefinition).value;
 
-                    const changeRequest = (value) =>
-                        registerChangeRequest(rowData, columnDefinition, value);
-                    const Editor = columnDefinition.editor;
-                    if (Editor) {
-                        return (
-                            <Editor
-                                key={columnDefinition.dataKey + key}
-                                className={clsx(
-                                    classes.tableCell,
-                                    classes.inlineEditionCell
-                                )}
-                                equipment={rowData}
-                                defaultValue={currentValue}
-                                setColumnError={(k) => setColumnInError(k)}
-                                resetColumnError={(k) => resetColumnInError(k)}
-                                forceLineUpdate={forceLineUpdate}
-                                columnDefinition={columnDefinition}
-                                setter={(val) => changeRequest(val)}
-                                style={style}
-                            />
-                        );
-                    }
+                const changeRequest = (value) =>
+                    registerChangeRequest(rowData, columnDefinition, value);
+                const Editor = columnDefinition.editor;
+                if (Editor) {
+                    return (
+                        <Editor
+                            key={columnDefinition.dataKey + key}
+                            className={clsx(
+                                classes.tableCell,
+                                classes.inlineEditionCell
+                            )}
+                            equipment={rowData}
+                            defaultValue={currentValue}
+                            setColumnError={(k) => setColumnInError(k)}
+                            resetColumnError={(k) => resetColumnInError(k)}
+                            forceLineUpdate={forceLineUpdate}
+                            columnDefinition={columnDefinition}
+                            setter={(val) => changeRequest(val)}
+                            style={style}
+                        />
+                    );
                 }
             }
             if (columnDefinition.boolean) {

--- a/src/components/network/network-table.js
+++ b/src/components/network/network-table.js
@@ -140,7 +140,11 @@ const useStyles = makeStyles((theme) => ({
         background:
             'linear-gradient(to right, ' +
             theme.palette.primary.main +
-            ', rgba(0,0,0,0) 10%)',
+            ' 0%, ' +
+            theme.palette.primary.main +
+            ' 2%, rgba(0,0,0,0) 12%)',
+        borderBottomLeftRadius: theme.spacing(0.5),
+        borderTopLeftRadius: theme.spacing(0.5),
     },
     topEditRow: {
         borderTop: '1px solid ' + theme.palette.primary.main,
@@ -782,7 +786,11 @@ const NetworkTable = (props) => {
                         )}
                     >
                         <div className={classes.editCell}>
-                            <IconButton size={'small'}>
+                            <IconButton
+                                size={'small'}
+                                style={{ backgroundColor: 'transparent' }}
+                                disableRipple
+                            >
                                 <MoreHorizIcon />
                             </IconButton>
                         </div>

--- a/src/components/network/network-table.js
+++ b/src/components/network/network-table.js
@@ -451,7 +451,16 @@ const NetworkTable = (props) => {
                 // When modifying a row, a shallow copy of the edited row is created and put on top of the table.
                 // The edition is then done on the copy, on top of the table, and not below, to prevent
                 // bugs of rows changing position in the middle of modifications.
-                return [result[parseInt(lineEdit.rowIndex) - 1], ...result];
+                let editRowPosition;
+                for (
+                    editRowPosition = 0;
+                    editRowPosition < result.length;
+                    editRowPosition++
+                ) {
+                    if (isLineOnEditMode(result[editRowPosition])) {
+                        return [result[editRowPosition], ...result];
+                    }
+                }
             }
             return result;
         },
@@ -463,7 +472,7 @@ const NetworkTable = (props) => {
             formatCell,
             props.disabled,
             isModifyingRow,
-            lineEdit,
+            isLineOnEditMode,
         ]
     );
 
@@ -812,7 +821,6 @@ const NetworkTable = (props) => {
                                         oldValues: {},
                                         newValues: {},
                                         id: rowData.id,
-                                        rowIndex: rowIndex,
                                         errors: new Map(),
                                         equipmentType:
                                             TABLES_DEFINITION_INDEXES.get(


### PR DESCRIPTION
Fixes a bug where the edited row number could change mid edit if columns were sorted. Now, we always search the correct row instead of storing the original row number.