### PR TITLE
Fix NetworkMapTab : Avoid geo data reload when useless 

### DIFF
--- a/src/components/network-map-tab.js
+++ b/src/components/network-map-tab.js
@@ -92,6 +92,7 @@ export const NetworkMapTab = ({
         (state) => state[PARAM_DISPLAY_OVERLOAD_TABLE]
     );
     const disabled = !visible || !isNodeBuilt(currentNode);
+    const reloadGeoDataNeeded = useSelector((state) => state.reloadGeoData);
     const [geoData, setGeoData] = useState();
 
     const [equipmentMenu, setEquipmentMenu] = useState({
@@ -187,6 +188,9 @@ export const NetworkMapTab = ({
         // if only renaming, do not reload geo data
         if (isNodeRenamed(previousCurrentNode, currentNode)) return;
         if (disabled) return;
+        // Hack to avoid reload Geo Data when switching display mode to TREE then back to MAP or HYBRID
+        // TODO REMOVE LATER
+        if (!reloadGeoDataNeeded) return;
 
         console.info(`Loading geo data of study '${studyUuid}'...`);
         const substationPositions = fetchSubstationPositions(
@@ -219,6 +223,7 @@ export const NetworkMapTab = ({
         // Note: studyUuid and dispatch don't change
     }, [
         disabled,
+        reloadGeoDataNeeded,
         studyUuid,
         currentNode,
         lineFullPath,

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -128,6 +128,10 @@ const initialState = {
     isModificationsInProgress: false,
     studyDisplayMode: STUDY_DISPLAY_MODE.HYBRID,
     ...paramsInitialState,
+    // Hack to avoid reload Geo Data when switching display mode to TREE then back to MAP or HYBRID
+    // defaulted to true to init load geo data with HYBRID defaulted display Mode
+    // TODO REMOVE LATER
+    reloadGeoData: true,
 };
 
 export const reducer = createReducer(initialState, {
@@ -233,6 +237,8 @@ export const reducer = createReducer(initialState, {
                 )
             ) {
                 synchCurrentTreeNode(state, state.currentTreeNode?.id);
+                // current node has changed, then will need to reload Geo Data
+                state.reloadGeoData = true;
             }
         }
     },
@@ -377,6 +383,8 @@ export const reducer = createReducer(initialState, {
     },
     [CURRENT_TREE_NODE]: (state, action) => {
         state.currentTreeNode = action.currentTreeNode;
+        // current node has changed, then will need to reload Geo Data
+        state.reloadGeoData = true;
     },
     [SET_MODIFICATIONS_DRAWER_OPEN]: (state, action) => {
         state.isModificationsDrawerOpen = action.isModificationsDrawerOpen;
@@ -407,6 +415,12 @@ export const reducer = createReducer(initialState, {
         if (
             Object.values(STUDY_DISPLAY_MODE).includes(action.studyDisplayMode)
         ) {
+            // Hack to avoid reload Geo Data when switching display mode to TREE then back to MAP or HYBRID
+            // Some actions in the TREE display mode could change this value after that
+            // ex: change current Node, current Node updated ...
+            if (action.studyDisplayMode === STUDY_DISPLAY_MODE.TREE)
+                state.reloadGeoData = false;
+
             state.studyDisplayMode = action.studyDisplayMode;
         }
     },


### PR DESCRIPTION
hack to avoid reload Geo Data when switching display mode to TREE then back to MAP or HYBRID

defaulted to true to init load geo data with HYBRID defaulted display Mode
TODO REMOVE LATER

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>