### PR TITLE
Fix : Remove duplicated keys in translation

### DIFF
--- a/src/components/dialogs/generator-creation-dialog.js
+++ b/src/components/dialogs/generator-creation-dialog.js
@@ -95,7 +95,7 @@ const GeneratorCreationDialog = ({
     const [rCCurveError, setRCCurveError] = useState();
 
     const headerIds = [
-        'ActivePower',
+        'ActivePowerText',
         'MinimumReactivePower',
         'MaximumReactivePower',
     ];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -135,7 +135,6 @@
     "LoadFlow": "LoadFlow",
     "Network": "Network",
     "SecurityAnalysis": "Security analysis",
-    "ShortCircuit": "Short-circuit analysis",
 
     "ContingencyListsSelection": "Contingency lists selection",
     "Execute": "Execute",
@@ -396,7 +395,6 @@
     "ReactiveCapabilityCurve": "Reactive capability curve",
     "MinimumReactivePower": "Minimum reactive power",
     "MaximumReactivePower": "Maximum reactive power",
-    "ActivePower": "Active power",
     "P": "P",
     "QminP": "QminP",
     "QmaxP": "QmaxP",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -136,7 +136,6 @@
     "LoadFlow": "Calcul de répartition",
     "Network": "Réseau",
     "SecurityAnalysis": "Analyse de sécurité",
-    "ShortCircuit": "Analyse de courts-circuits systématique",
 
     "ContingencyListsSelection": "Sélection des listes d'aléas",
     "Execute": "Exécuter",
@@ -397,7 +396,6 @@
     "ReactiveCapabilityCurve": "Limites de réactif par diagramme",
     "MinimumReactivePower": "Puissance réactive minimale",
     "MaximumReactivePower": "Puissance réactive maximale",
-    "ActivePower": "Puissance active",
     "P": "P",
     "QminP": "QminP",
     "QmaxP": "QmaxP",


### PR DESCRIPTION
use existing one in generator-creation-dialog to avoid using the network table header one

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>