### PR TITLE
Use optional enum fields in Load and Generator modifications

### DIFF
--- a/src/components/dialogs/generator-creation-dialog.js
+++ b/src/components/dialogs/generator-creation-dialog.js
@@ -23,7 +23,7 @@ import { useSnackbar } from 'notistack';
 import {
     useButtonWithTooltip,
     useDoubleValue,
-    useEnumValue,
+    useOptionalEnumValue,
     useInputForm,
     useRegulatingTerminalValue,
     useTableValues,
@@ -68,7 +68,7 @@ const useStyles = makeStyles((theme) => ({
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
  * @param voltageLevelOptionsPromise Promise handling list of voltage level options
- * @param currentNodeUuid : the currently selected tree node
+ * @param currentNodeUuid the currently selected tree node
  * @param editData the data to edit
  */
 const GeneratorCreationDialog = ({
@@ -168,15 +168,15 @@ const GeneratorCreationDialog = ({
         defaultValue: formValues?.equipmentName,
     });
 
-    const [energySource, energySourceField] = useEnumValue({
+    const [energySource, energySourceField] = useOptionalEnumValue({
         label: 'EnergySourceText',
         inputForm: inputForm,
         formProps: filledTextField,
-        enumValues: ENERGY_SOURCES,
+        enumObjects: ENERGY_SOURCES,
         validation: {
             isFieldRequired: false,
         },
-        defaultValue: formValues?.energySource,
+        defaultValue: formValues?.energySource ?? null,
     });
 
     const [maximumActivePower, maximumActivePowerField] = useDoubleValue({
@@ -382,7 +382,7 @@ const GeneratorCreationDialog = ({
                 currentNodeUuid,
                 generatorId,
                 sanitizeString(generatorName),
-                !energySource ? 'OTHER' : energySource,
+                energySource,
                 minimumActivePower,
                 maximumActivePower,
                 ratedNominalPower ? ratedNominalPower : null,

--- a/src/components/dialogs/generator-modification-dialog.js
+++ b/src/components/dialogs/generator-modification-dialog.js
@@ -18,7 +18,7 @@ import { useSnackMessage } from '../../utils/messages';
 import makeStyles from '@mui/styles/makeStyles';
 import {
     useDoubleValue,
-    useEnumValue,
+    useOptionalEnumValue,
     useInputForm,
     useTextValue,
 } from './inputs/input-hooks';
@@ -59,7 +59,7 @@ function getValueOrNull(val) {
  * Dialog to create a generator in the network
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
- * @param currentNodeUuid : the currently selected tree node
+ * @param currentNodeUuid the currently selected tree node
  * @param equipmentOptionsPromise Promise handling list of generator options
  * @param editData the data to edit
  */
@@ -141,14 +141,15 @@ const GeneratorModificationDialog = ({
           })
         : undefined;
 
-    const [energySource, energySourceField] = useEnumValue({
+    const [energySource, energySourceField] = useOptionalEnumValue({
         label: 'EnergySourceText',
         inputForm: inputForm,
         formProps: filledTextField,
-        enumValues: ENERGY_SOURCES,
-        defaultValue: getValue(formValues?.energySource),
+        enumObjects: ENERGY_SOURCES,
+        defaultValue: formValues?.energySource
+            ? formValues.energySource.value
+            : null,
         previousValue: previousEnergySourceLabel,
-        clearable: true,
     });
 
     const [maximumActivePower, maximumActivePowerField] = useDoubleValue({

--- a/src/components/dialogs/inputs/input-hooks.js
+++ b/src/components/dialogs/inputs/input-hooks.js
@@ -271,12 +271,15 @@ export const useOptionalEnumValue = (props) => {
         [intl, props.enumObjects]
     );
 
+    // because we want to have the clear icon to possibly reset the optional enum value to null,
+    // we use an Autocomplete without the ability to enter some letters in the text field (readonly then).
     return useAutocompleteField({
         values: props.enumObjects.map((enumObject) => enumObject.id),
         selectedValue: props.defaultValue,
         defaultValue: props.defaultValue,
         previousValue: props.previousValue,
         getLabel: getEnumTranslation,
+        readOnlyTextField: true,
         ...props,
     });
 };

--- a/src/components/dialogs/inputs/input-hooks.js
+++ b/src/components/dialogs/inputs/input-hooks.js
@@ -255,6 +255,32 @@ export const useButtonWithTooltip = ({ handleClick, label }) => {
     }, [label, handleClick, classes.tooltip]);
 };
 
+export const useOptionalEnumValue = (props) => {
+    const intl = useIntl();
+
+    const getEnumTranslation = useCallback(
+        (enumValue) => {
+            // translate the label of enumValue
+            const enumTranslation = props.enumObjects
+                .filter((e) => e.id === enumValue)
+                .map((e) => intl.formatMessage({ id: e.label }));
+            return enumTranslation.length === 1
+                ? enumTranslation.at(0)
+                : enumValue;
+        },
+        [intl, props.enumObjects]
+    );
+
+    return useAutocompleteField({
+        values: props.enumObjects.map((enumObject) => enumObject.id),
+        selectedValue: props.defaultValue,
+        defaultValue: props.defaultValue,
+        previousValue: props.previousValue,
+        getLabel: getEnumTranslation,
+        ...props,
+    });
+};
+
 export const useCountryValue = (props) => {
     const [languageLocal] = useParameterState(PARAM_LANGUAGE);
     const [code, setCode] = useState(props.defaultCodeValue);

--- a/src/components/dialogs/inputs/use-autocomplete-field.js
+++ b/src/components/dialogs/inputs/use-autocomplete-field.js
@@ -85,6 +85,7 @@ export const useAutocompleteField = ({
     defaultValue,
     previousValue,
     loading = false,
+    readOnlyTextField = false,
 }) => {
     const intl = useIntl();
 
@@ -284,6 +285,10 @@ export const useAutocompleteField = ({
                             />
                         }
                         value={value}
+                        inputProps={{
+                            ...props.inputProps,
+                            readOnly: readOnlyTextField,
+                        }}
                         {...genHelperPreviousValue(previousValue)}
                         {...genHelperError(error, errorMsg)}
                     />
@@ -311,6 +316,7 @@ export const useAutocompleteField = ({
         renderElement,
         onOpen,
         userStr,
+        readOnlyTextField,
     ]);
 
     return [value, field, setValue];

--- a/src/components/dialogs/load-creation-dialog.js
+++ b/src/components/dialogs/load-creation-dialog.js
@@ -22,7 +22,7 @@ import {
 import { LOAD_TYPES } from '../network/constants';
 import {
     useDoubleValue,
-    useEnumValue,
+    useOptionalEnumValue,
     useInputForm,
     useButtonWithTooltip,
     useTextValue,
@@ -46,7 +46,7 @@ import { useConnectivityValue } from './connectivity-edition';
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
  * @param voltageLevelOptionsPromise Promise handling list of voltage level options
- * @param currentNodeUuid : the node we are currently working on
+ * @param currentNodeUuid The node we are currently working on
  * @param editData the data to edit
  */
 const LoadCreationDialog = ({
@@ -115,13 +115,13 @@ const LoadCreationDialog = ({
         defaultValue: formValues?.equipmentName,
     });
 
-    const [loadType, loadTypeField] = useEnumValue({
+    const [loadType, loadTypeField] = useOptionalEnumValue({
         label: 'Type',
         validation: { isFieldRequired: false },
         inputForm: inputForm,
         formProps: filledTextField,
-        enumValues: LOAD_TYPES,
-        defaultValue: formValues ? formValues.loadType : '',
+        enumObjects: LOAD_TYPES,
+        defaultValue: formValues?.loadType ?? null,
     });
 
     const [activePower, activePowerField] = useDoubleValue({
@@ -168,7 +168,7 @@ const LoadCreationDialog = ({
                 currentNodeUuid,
                 loadId,
                 sanitizeString(loadName),
-                !loadType ? 'UNDEFINED' : loadType,
+                loadType,
                 activePower,
                 reactivePower,
                 connectivity.voltageLevel.id,

--- a/src/components/dialogs/load-modification-dialog.js
+++ b/src/components/dialogs/load-modification-dialog.js
@@ -23,7 +23,7 @@ import { modifyLoad } from '../../utils/rest-api';
 import { LOAD_TYPES } from '../network/constants';
 import {
     useDoubleValue,
-    useEnumValue,
+    useOptionalEnumValue,
     useInputForm,
     useTextValue,
 } from './inputs/input-hooks';
@@ -44,7 +44,7 @@ import { useAutocompleteField } from './inputs/use-autocomplete-field';
  * @param {Boolean} open Is the dialog open ?
  * @param {EventListener} onClose Event to close the dialog
  * @param equipmentOptionsPromise Promise handling list of loads that can be modified
- * @param currentNodeUuid : the node we are currently working on
+ * @param currentNodeUuid the node we are currently working on
  * @param editData the data to edit
  */
 const LoadModificationDialog = ({
@@ -114,13 +114,12 @@ const LoadModificationDialog = ({
         clearable: true,
     });
 
-    const [loadType, loadTypeField] = useEnumValue({
+    const [loadType, loadTypeField] = useOptionalEnumValue({
         label: 'Type',
         inputForm: inputForm,
         formProps: filledTextField,
-        enumValues: LOAD_TYPES,
-        defaultValue: formValues?.loadType ? formValues.loadType.value : '',
-        doTranslation: true,
+        enumObjects: LOAD_TYPES,
+        defaultValue: formValues?.loadType ? formValues.loadType.value : null,
         previousValue: loadInfos?.type
             ? LOAD_TYPES.find((lt) => lt.id === loadInfos.type)?.label
             : undefined,

--- a/src/components/network/config-tables.js
+++ b/src/components/network/config-tables.js
@@ -596,7 +596,7 @@ export const TABLES_DEFINITIONS = {
                 changeCmd: 'equipment.setEnergySource(EnergySource.{})\n',
                 editor: ({ equipment, ...props }) =>
                     EnumField({
-                        enumList: ENERGY_SOURCES.slice(1), // dont use/display the first empty entry
+                        enumList: ENERGY_SOURCES,
                         ...props,
                     }),
             },
@@ -719,7 +719,7 @@ export const TABLES_DEFINITIONS = {
                 changeCmd: 'equipment.setLoadType(LoadType.{})\n',
                 editor: ({ equipment, ...props }) =>
                     EnumField({
-                        enumList: LOAD_TYPES.slice(1), // dont use/display the first empty entry
+                        enumList: LOAD_TYPES,
                         ...props,
                     }),
             },

--- a/src/components/network/constants.js
+++ b/src/components/network/constants.js
@@ -10,14 +10,12 @@ export const SUBSTATION_RADIUS_MAX_PIXEL = 5;
 export const SUBSTATION_RADIUS_MIN_PIXEL = 1;
 
 export const LOAD_TYPES = [
-    { id: '', label: 'None' },
     { id: 'UNDEFINED', label: 'UndefinedDefaultValue' },
     { id: 'AUXILIARY', label: 'Auxiliary' },
     { id: 'FICTITIOUS', label: 'Fictitious' },
 ];
 
 export const ENERGY_SOURCES = [
-    { id: '', label: 'None' },
     { id: 'HYDRO', label: 'Hydro' },
     { id: 'NUCLEAR', label: 'Nuclear' },
     { id: 'WIND', label: 'Wind' },


### PR DESCRIPTION
For optional enum fields, we want to have a clear icon in order to reset the enum value to undefined.