### PR TITLE
fix memory leak when clicking on a switch

### DIFF
--- a/src/components/study-container.js
+++ b/src/components/study-container.js
@@ -601,7 +601,7 @@ export function StudyContainer({ view, onChangeTab }) {
             //.finally(() => setIsNetworkPending(false));
             // Note: studyUuid don't change
         },
-        [studyUuid, currentNode?.id, network]
+        [studyUuid, currentNode, network]
     );
 
     useEffect(() => {


### PR DESCRIPTION
when clicking a switch, we get a memory leak like this: network in
  context in
    loadNetwork in
      context in
        updateNetwork in
          context in
            loadNetwork in
              ...

update updateNetwork at the same time as loadNetwork in this case (when currentNode is changed shallowly but the id doesn't change) to break the loop (even though updateNetwork doesn't need to be updated)