### PR TITLE
fix a network memory leak in NodeEditor when clicking on a switch

### DIFF
--- a/src/components/graph/menus/modification-list-item.js
+++ b/src/components/graph/menus/modification-list-item.js
@@ -73,7 +73,6 @@ export const ModificationListItem = ({
         [modif, handleToggle]
     );
 
-
     // hack to avoid the capture of network by closures, which leads to memory leaks
     let computedValues;
     const networkCopy = network;

--- a/src/components/graph/menus/modification-list-item.js
+++ b/src/components/graph/menus/modification-list-item.js
@@ -73,27 +73,34 @@ export const ModificationListItem = ({
         [modif, handleToggle]
     );
 
-    const computedValues = useMemo(() => {
-        function getVoltageLevelLabel(vlID) {
-            if (!vlID) return '';
-            const vl = network.getVoltageLevel(vlID);
-            if (vl) return vl[useName ? 'name' : 'id'] || vlID;
-            return vlID;
-        }
-        let res = { computedLabel: <strong>{getComputedLabel()}</strong> };
-        if (modif.type === 'BRANCH_STATUS') {
-            if (modif.action === 'ENERGISE_END_ONE') {
-                res.energizedEnd = getVoltageLevelLabel(
-                    network.getLine(modif.equipmentId)?.voltageLevelId1
-                );
-            } else if (modif.action === 'ENERGISE_END_TWO') {
-                res.energizedEnd = getVoltageLevelLabel(
-                    network.getLine(modif.equipmentId)?.voltageLevelId2
-                );
+
+    // hack to avoid the capture of network by closures, which leads to memory leaks
+    let computedValues;
+    const networkCopy = network;
+    {
+        const network = networkCopy;
+        computedValues = useMemo(() => {
+            function getVoltageLevelLabel(vlID) {
+                if (!vlID) return '';
+                const vl = network.getVoltageLevel(vlID);
+                if (vl) return vl[useName ? 'name' : 'id'] || vlID;
+                return vlID;
             }
-        }
-        return res;
-    }, [modif, network, getComputedLabel, useName]);
+            let res = { computedLabel: <strong>{getComputedLabel()}</strong> };
+            if (modif.type === 'BRANCH_STATUS') {
+                if (modif.action === 'ENERGISE_END_ONE') {
+                    res.energizedEnd = getVoltageLevelLabel(
+                        network.getLine(modif.equipmentId)?.voltageLevelId1
+                    );
+                } else if (modif.action === 'ENERGISE_END_TWO') {
+                    res.energizedEnd = getVoltageLevelLabel(
+                        network.getLine(modif.equipmentId)?.voltageLevelId2
+                    );
+                }
+            }
+            return res;
+        }, [modif, network, getComputedLabel, useName]);
+    }
 
     const getLabel = useCallback(
         () =>

--- a/src/components/graph/menus/network-modification-node-editor.js
+++ b/src/components/graph/menus/network-modification-node-editor.js
@@ -595,7 +595,7 @@ const NetworkModificationNodeEditor = () => {
         );
     };
 
-    const renderNetworkModificationsList = () => {
+    const renderNetworkModificationsList = (network) => {
         return (
             <DragDropContext
                 onDragEnd={commit}
@@ -761,7 +761,7 @@ const NetworkModificationNodeEditor = () => {
             </Toolbar>
             {renderPaneSubtitle()}
 
-            {renderNetworkModificationsList()}
+            {renderNetworkModificationsList(network)}
             <Fab
                 className={classes.addButton}
                 color="primary"

--- a/src/components/study-container.js
+++ b/src/components/study-container.js
@@ -601,7 +601,7 @@ export function StudyContainer({ view, onChangeTab }) {
             //.finally(() => setIsNetworkPending(false));
             // Note: studyUuid don't change
         },
-        [studyUuid, currentNode?.id, network]
+        [studyUuid, currentNode, network]
     );
 
     useEffect(() => {


### PR DESCRIPTION
Each new modification (dom element) holds a reference to the network at the time of the click, even though it doesn't use it.

The memory leak looks like

network in
  context in
    onClick in
      props in
        children in
          __reactProps$d134hf12125 in
           divElement in
            ...

Fix it by not having a network variable in scope when we create the jsx (this is because the reconciler reuses an intermediate div element that doesn't change, which holds references to all the props of the children. onClick itself doesn't use network, it gets a reference to network because it is in the single closure capture context of the scope)