### PR TITLE
Removes a warning cause by a missing key in a map.

### DIFF
--- a/src/components/dialogs/generator-creation-dialog.js
+++ b/src/components/dialogs/generator-creation-dialog.js
@@ -606,8 +606,12 @@ const GeneratorCreationDialog = ({
                                     <Grid container spacing={2}>
                                         <Grid item xs={12}>
                                             {reactiveCapabilityCurveErrors.map(
-                                                (messageDescriptorId) => (
+                                                (
+                                                    messageDescriptorId,
+                                                    index
+                                                ) => (
                                                     <div
+                                                        key={index}
                                                         className={
                                                             classes.midFormErrorMessage
                                                         }


### PR DESCRIPTION
Signed-off-by: BOUTIER Charly <charly.boutier@rte-france.com>