### PR TITLE
Generalize adapt usage in NetworkModificationNodeEditor

### DIFF
--- a/src/components/graph/menus/network-modification-node-editor.js
+++ b/src/components/graph/menus/network-modification-node-editor.js
@@ -342,7 +342,7 @@ const NetworkModificationNodeEditor = () => {
         },
         EQUIPMENT_DELETION: {
             label: 'DeleteEquipment',
-            dialog: () => withDefaultParams(EquipmentDeletionDialog),
+            dialog: () => adapt(EquipmentDeletionDialog),
             icon: <DeleteIcon />,
         },
     };

--- a/src/components/graph/menus/network-modification-node-editor.js
+++ b/src/components/graph/menus/network-modification-node-editor.js
@@ -304,7 +304,7 @@ const NetworkModificationNodeEditor = () => {
         },
         SUBSTATION_CREATION: {
             label: 'CreateSubstation',
-            dialog: () => withDefaultParams(SubstationCreationDialog),
+            dialog: () => adapt(SubstationCreationDialog),
             icon: <AddIcon />,
         },
         VOLTAGE_LEVEL_CREATION: {


### PR DESCRIPTION
refactor(NetworkModificationNodeEditor): generalize adapt usage (which forward the defaultParams) to homogeneize the code

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>