### PR TITLE
Fix GeneratorCreationDialog: voltageRegulationTypeField variant

### DIFF
--- a/src/components/dialogs/generator-creation-dialog.js
+++ b/src/components/dialogs/generator-creation-dialog.js
@@ -315,7 +315,6 @@ const GeneratorCreationDialog = ({
     const [voltageRegulationType, voltageRegulationTypeField] = useEnumValue({
         label: 'RegulationTypeText',
         inputForm: inputForm,
-        formProps: filledTextField,
         enumValues: Object.values(REGULATION_TYPES),
         validation: {
             isFieldRequired: voltageRegulation,


### PR DESCRIPTION
fix(GeneratorCreationDialog): voltageRegulationTypeField variant passed to default one (outlined)

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>