### PR TITLE
Disables the VoltageSetPoint field when not in use

### DIFF
--- a/src/components/dialogs/generator-creation-dialog.js
+++ b/src/components/dialogs/generator-creation-dialog.js
@@ -298,6 +298,7 @@ const GeneratorCreationDialog = ({
         },
         adornment: VoltageAdornment,
         inputForm: inputForm,
+        formProps: { disabled: !voltageRegulation },
         defaultValue: formValues?.voltageSetpoint,
     });
 


### PR DESCRIPTION
Disables the VoltageSetPoint field when not in use to prevent a validation error if a generator is copied from another.

Signed-off-by: BOUTIER Charly <charly.boutier@rte-france.com>