### PR TITLE
Temporary fix to prevent the NAD for overlapping the tree

### DIFF
--- a/src/components/diagrams/networkAreaDiagram/network-area-diagram.js
+++ b/src/components/diagrams/networkAreaDiagram/network-area-diagram.js
@@ -45,7 +45,8 @@ import clsx from 'clsx';
 import { RunningStatus } from '../../util/running-status';
 import AlertInvalidNode from '../../util/alert-invalid-node';
 
-const loadingWidth = 150;
+const loadingWidth = 200;
+const loadingHeight = 250;
 const maxWidth = 1200;
 const maxHeight = 650;
 const minWidth = 500;
@@ -388,9 +389,9 @@ const SizedNetworkAreaDiagram = (props) => {
             className={classes.paperBorders}
             style={{
                 pointerEvents: 'auto',
-                width: sizeWidth,
+                width: loadingState ? loadingWidth : sizeWidth,
                 minWidth: loadingState ? loadingWidth : 0,
-                height: sizeHeight,
+                height: loadingState ? loadingHeight : sizeHeight,
                 position: 'relative',
                 direction: 'ltr',
                 overflow: 'hidden',
@@ -485,8 +486,11 @@ const SizedNetworkAreaDiagram = (props) => {
 };
 
 const NetworkAreaDiagram = (props) => {
+    // Hack : A key is added to the AutoSizer to force an update when the panel's size changes,
+    // instead of only calculating the size on first load and keeping it after that.
+    const studyDisplayMode = useSelector((state) => state.studyDisplayMode);
     return (
-        <AutoSizer>
+        <AutoSizer key={studyDisplayMode}>
             {({ width, height }) => (
                 <SizedNetworkAreaDiagram
                     totalWidth={width}


### PR DESCRIPTION
Temporary fix to prevent the NAD for overlapping the tree when switching from MAP display to HYBRID display.

Signed-off-by: BOUTIER Charly <charly.boutier@rte-france.com>