### PR TITLE
Fix tap validation in 2w transformer creation

### DIFF
--- a/src/components/dialogs/two-windings-transformer/phase-tap-changer-pane.js
+++ b/src/components/dialogs/two-windings-transformer/phase-tap-changer-pane.js
@@ -86,7 +86,7 @@ const PhaseTapChangerPane = (props) => {
     };
 
     const generateTapRows = () => {
-        if (highTapPosition - lowTapPosition > MAX_TAP_NUMBER) {
+        if (highTapPosition - lowTapPosition + 1 > MAX_TAP_NUMBER) {
             setRatioError(
                 intl.formatMessage(
                     { id: 'TapPositionValueError' },

--- a/src/components/dialogs/two-windings-transformer/phase-tap-changer-pane.js
+++ b/src/components/dialogs/two-windings-transformer/phase-tap-changer-pane.js
@@ -86,7 +86,7 @@ const PhaseTapChangerPane = (props) => {
     };
 
     const generateTapRows = () => {
-        if (highTapPosition > MAX_TAP_NUMBER) {
+        if (highTapPosition - lowTapPosition > MAX_TAP_NUMBER) {
             setRatioError(
                 intl.formatMessage(
                     { id: 'TapPositionValueError' },

--- a/src/components/dialogs/two-windings-transformer/ratio-tap-changer-pane.js
+++ b/src/components/dialogs/two-windings-transformer/ratio-tap-changer-pane.js
@@ -83,7 +83,7 @@ const RatioTapChangerPane = (props) => {
     };
 
     const generateTapRows = () => {
-        if (highTapPosition > MAX_TAP_NUMBER) {
+        if (highTapPosition - lowTapPosition > MAX_TAP_NUMBER) {
             setRatioError(
                 intl.formatMessage(
                     { id: 'TapPositionValueError' },

--- a/src/components/dialogs/two-windings-transformer/ratio-tap-changer-pane.js
+++ b/src/components/dialogs/two-windings-transformer/ratio-tap-changer-pane.js
@@ -83,7 +83,7 @@ const RatioTapChangerPane = (props) => {
     };
 
     const generateTapRows = () => {
-        if (highTapPosition - lowTapPosition > MAX_TAP_NUMBER) {
+        if (highTapPosition - lowTapPosition + 1 > MAX_TAP_NUMBER) {
             setRatioError(
                 intl.formatMessage(
                     { id: 'TapPositionValueError' },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -530,7 +530,7 @@
     "IncoherentPhaseRegulatingTerminalError": "The phase tap Regulating terminal value must be filled",
     "RatioValuesError": "The values of the ratio tap ratios must be ordered and without duplicates",
     "PhaseShiftValuesError": "The values of the phase tap ratios must be ordered and without duplicates",
-    "TapPositionValueError": "The high tap position must not exceed the value {value}",
+    "TapPositionValueError": "The number of tap must not exceed the value {value}",
 
     "Tap":"Tap",
     "DeltaResistance":"Δ Resistance (%)",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -530,7 +530,7 @@
     "IncoherentPhaseRegulatingTerminalError": "The phase tap Regulating terminal value must be filled",
     "RatioValuesError": "The values of the ratio tap ratios must be ordered and without duplicates",
     "PhaseShiftValuesError": "The values of the phase tap ratios must be ordered and without duplicates",
-    "TapPositionValueError": "The number of tap must not exceed the value {value}",
+    "TapPositionValueError": "The number of taps must not exceed the value {value}",
 
     "Tap":"Tap",
     "DeltaResistance":"Δ Resistance (%)",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -530,7 +530,7 @@
     "IncoherentPhaseRegulatingTerminalError": "La valeur du Terminal distant réglé du déphaseur doit être renseignée",
     "RatioValuesError": "Les rapports de transformation doivent être ordonnés et sans duplication",
     "PhaseShiftValuesError": "les valeurs de déphasage doivent être ordonnés et sans duplication",
-    "TapPositionValueError": "La prise maximale ne doit pas dépasser la valeur {value}",
+    "TapPositionValueError": "Le nombre de prise ne doit pas dépasser la valeur {value}",
 
     "Tap":"Prise",
     "DeltaResistance":"Δ Résistance (%)",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -530,7 +530,7 @@
     "IncoherentPhaseRegulatingTerminalError": "La valeur du Terminal distant réglé du déphaseur doit être renseignée",
     "RatioValuesError": "Les rapports de transformation doivent être ordonnés et sans duplication",
     "PhaseShiftValuesError": "les valeurs de déphasage doivent être ordonnés et sans duplication",
-    "TapPositionValueError": "Le nombre de prise ne doit pas dépasser la valeur {value}",
+    "TapPositionValueError": "Le nombre de prises ne doit pas dépasser la valeur {value}",
 
     "Tap":"Prise",
     "DeltaResistance":"Δ Résistance (%)",


### PR DESCRIPTION
- When validating the high tab and low tab values in row generation, check the number of taps instead of the high tap value.
- Change error message