### PR TITLE
change tables keys to string to make it unique

### DIFF
--- a/src/components/dialogs/two-windings-transformer/phase-tap-changer-pane.js
+++ b/src/components/dialogs/two-windings-transformer/phase-tap-changer-pane.js
@@ -301,6 +301,7 @@ const PhaseTapChangerPane = (props) => {
         // We generate a unique key for the table because when we change alpha value by creating a new rule for example,
         // the table does not update only by scrolling. With this key we make sure it is updated when creating a new rule
         return (
+            '' +
             phaseTapRows[0]?.alpha +
             phaseTapRows[phaseTapRows.length - 1]?.alpha
         );

--- a/src/components/dialogs/two-windings-transformer/ratio-tap-changer-pane.js
+++ b/src/components/dialogs/two-windings-transformer/ratio-tap-changer-pane.js
@@ -299,6 +299,7 @@ const RatioTapChangerPane = (props) => {
         // We generate a unique key for the table because when we change alpha value by creating a new rule for example,
         // the table does not update only by scrolling. With this key we make sure it is updated when creating a new rule
         return (
+            '' +
             ratioTapRows[0]?.ratio +
             ratioTapRows[ratioTapRows.length - 1]?.ratio
         );


### PR DESCRIPTION
This glitch can be seen when creating a new rule does not change the key of the table in 2W transformer creation dialogue.
Changing the key to string ensure the key is always unique and change each time we create a new rule