### PR TITLE
fix sld display when selecting a node not built

### DIFF
--- a/src/components/diagrams/singleLineDiagram/single-line-diagram.js
+++ b/src/components/diagrams/singleLineDiagram/single-line-diagram.js
@@ -51,7 +51,7 @@ import clsx from 'clsx';
 import AlertInvalidNode from '../../util/alert-invalid-node';
 import { useIsAnyNodeBuilding } from '../../util/is-any-node-building-hook';
 import Alert from '@mui/material/Alert';
-import { isNodeReadOnly } from '../../graph/util/model-functions';
+import { isNodeBuilt, isNodeReadOnly } from '../../graph/util/model-functions';
 import { SingleLineDiagramViewer } from '@powsybl/diagram-viewer';
 
 export const SubstationLayout = {
@@ -715,6 +715,10 @@ const SingleLineDiagram = forwardRef((props, ref) => {
         sizeWidth = initialWidth;
     } else {
         sizeWidth = totalWidth; // happens during initialization if initial width value is undefined
+    }
+
+    if (!isNodeBuilt(currentNode)) {
+        sizeWidth = totalWidth / numberToDisplay;
     }
 
     if (sizeWidth !== undefined) {


### PR DESCRIPTION
When working on node not built, opening multiple SLD can lead to some of them being displayed out of the screen because we take the size of the last sld,
This PR is to make sure when opening multiple sld and the current node is not built, each sld will be displayed inside the screen. 