### PR TITLE
Droop field blocks validation even if it had a previous value

### DIFF
--- a/src/components/dialogs/generator-modification-dialog.js
+++ b/src/components/dialogs/generator-modification-dialog.js
@@ -492,7 +492,9 @@ const GeneratorModificationDialog = ({
 
     const [droop, droopField] = useDoubleValue({
         label: 'Droop',
-        validation: { isFieldRequired: frequencyRegulation },
+        validation: {
+            isFieldRequired: frequencyRegulation && !generatorInfos?.droop, // The field is required if active power regulation is ON and there is no previous value.
+        },
         adornment: percentageTextField,
         inputForm: inputForm,
         formProps: {


### PR DESCRIPTION
In the generator modification dialog, prevents the droop field from blocking the validation if active power regulation is ON and there was already a value.

Signed-off-by: BOUTIER Charly <charly.boutier@rte-france.com>