### PR TITLE
fix sld voltagelevel titles, put back country when available

### DIFF
--- a/src/components/diagrams/singleLineDiagram/single-line-diagram-pane.js
+++ b/src/components/diagrams/singleLineDiagram/single-line-diagram-pane.js
@@ -126,7 +126,7 @@ const useDisplayView = (network, studyUuid, currentNode) => {
                 const vl = network.getVoltageLevel(vlId);
                 if (!vl) return;
                 let label = getNameOrId(vl);
-                const substation = network.getSubstation(vlId);
+                const substation = network.getSubstation(vl.substationId);
                 const countryName = substation?.countryName;
                 if (countryName) {
                     label += ' - ' + countryName;


### PR DESCRIPTION
regression from e3aa1d9be03d7a39edd88c5d4033a91daad40d92
```
-            sldTitle +=
-                ' \u002D ' +
-                network.getSubstation(displayedSubstation.id).countryName;
+                const substation = network.getSubstation(vlId);
+                const countryName = substation?.countryName;
+                if (countryName) {
+                    name += ' \u002D ' + countryName;
+                }
```