### PR TITLE
Add optional startup fields

### DIFF
--- a/src/components/dialogs/generator-creation-dialog.js
+++ b/src/components/dialogs/generator-creation-dialog.js
@@ -413,6 +413,7 @@ const GeneratorCreationDialog = ({
     const [plannedActivePowerSetPoint, plannedActivePowerSetPointField] =
         useDoubleValue({
             label: 'PlannedActivePowerSetPoint',
+            validation: { isFieldRequired: false },
             adornment: ActivePowerAdornment,
             inputForm: inputForm,
             defaultValue: formValues?.plannedActivePowerSetPoint,
@@ -420,12 +421,14 @@ const GeneratorCreationDialog = ({
 
     const [startupCost, startupCostField] = useDoubleValue({
         label: 'StartupCost',
+        validation: { isFieldRequired: false },
         inputForm: inputForm,
         defaultValue: formValues?.startupCost,
     });
 
     const [marginalCost, marginalCostField] = useDoubleValue({
         label: 'MarginalCost',
+        validation: { isFieldRequired: false },
         inputForm: inputForm,
         defaultValue: formValues?.marginalCost,
     });
@@ -433,6 +436,7 @@ const GeneratorCreationDialog = ({
     const [plannedOutageRate, plannedOutageRateField] = useDoubleValue({
         label: 'PlannedOutageRate',
         validation: {
+            isFieldRequired: false,
             valueGreaterThanOrEqualTo: '0',
             valueLessThanOrEqualTo: '1',
             errorMsgId: 'RealPercentage',
@@ -444,6 +448,7 @@ const GeneratorCreationDialog = ({
     const [forcedOutageRate, forcedOutageRateField] = useDoubleValue({
         label: 'ForcedOutageRate',
         validation: {
+            isFieldRequired: false,
             valueGreaterThanOrEqualTo: '0',
             valueLessThanOrEqualTo: '1',
             errorMsgId: 'RealPercentage',


### PR DESCRIPTION
Add optional in the placeholder of startup fields in the generator creation dialog

Signed-off-by: Florent MILLOT <millotflo@gmail.com>