### PR TITLE
Gitignore the coverage folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # webstorm
 /.idea
+/coverage
 
 # misc
 .env.local


### PR DESCRIPTION
Gitignore the coverage folder created when using unit tests with coverage.

Signed-off-by: BOUTIER Charly <charly.boutier@rte-france.com>