### PR TITLE
Fix small network opening

### DIFF
--- a/src/components/network-map-tab.js
+++ b/src/components/network-map-tab.js
@@ -112,7 +112,6 @@ export const NetworkMapTab = ({
 
     const [geoData, setGeoData] = useState();
     const geoDataRef = useRef();
-    geoDataRef.current = geoData;
 
     const basicDataReady = mapEquipments && geoData;
 
@@ -439,6 +438,7 @@ export const NetworkMapTab = ({
                             fetchedLinePositions
                         );
                         setGeoData(newGeoData);
+                        geoDataRef.current = newGeoData;
                     }
                 })
                 .catch(function (error) {

--- a/src/components/network-map-tab.js
+++ b/src/components/network-map-tab.js
@@ -112,6 +112,7 @@ export const NetworkMapTab = ({
 
     const [geoData, setGeoData] = useState();
     const geoDataRef = useRef();
+    geoDataRef.current = geoData;
 
     const basicDataReady = mapEquipments && geoData;
 

--- a/src/components/network-map-tab.js
+++ b/src/components/network-map-tab.js
@@ -112,7 +112,6 @@ export const NetworkMapTab = ({
 
     const [geoData, setGeoData] = useState();
     const geoDataRef = useRef();
-    geoDataRef.current = geoData;
 
     const basicDataReady = mapEquipments && geoData;
 
@@ -480,6 +479,7 @@ export const NetworkMapTab = ({
             );
             newGeoData.setSubstationPositions(data);
             setGeoData(newGeoData);
+            geoDataRef.current = newGeoData;
         });
 
         const linePositionsDone = !lineFullPath
@@ -494,6 +494,7 @@ export const NetworkMapTab = ({
                       );
                       newGeoData.setLinePositions(data);
                       setGeoData(newGeoData);
+                      geoDataRef.current = newGeoData;
                   }
               );
 


### PR DESCRIPTION
geoDataRef is used for positions initialization. The "then" of the fetchSubstationPositions and fetchLinePositions promises are executed without any render between them if the requests finish almost at the same time. So we must set the ref immadiately instead of waiting for the next render. 

Signed-off-by: Etienne Homer <etiennehomer@gmail.com>