### PR TITLE
Widens the overloaded line table

### DIFF
--- a/src/components/network-map-tab.js
+++ b/src/components/network-map-tab.js
@@ -68,7 +68,7 @@ const useStyles = makeStyles((theme) => ({
     divOverloadedLineView: {
         right: 45,
         top: 10,
-        minWidth: '500px',
+        minWidth: '600px',
         position: 'absolute',
         height: '70%',
         opacity: '1',

--- a/src/components/network/overloaded-lines-view.js
+++ b/src/components/network/overloaded-lines-view.js
@@ -171,7 +171,7 @@ const OverloadedLinesView = (props) => {
                     sortable={true}
                     columns={[
                         {
-                            width: 150,
+                            width: 180,
                             label: intl.formatMessage({ id: 'Name' }),
                             dataKey: 'name',
                             numeric: false,
@@ -186,7 +186,7 @@ const OverloadedLinesView = (props) => {
                             label: intl.formatMessage({ id: 'Load' }),
                             dataKey: 'load',
                             numeric: true,
-                            width: 70,
+                            width: 120,
                             fractionDigits: 1,
                             headerRenderer: ({ label }) => MakeHead(label),
                         },
@@ -194,7 +194,7 @@ const OverloadedLinesView = (props) => {
                             label: intl.formatMessage({ id: 'Intensity' }),
                             dataKey: 'intensity',
                             numeric: true,
-                            width: 70,
+                            width: 120,
                             headerRenderer: ({ label }) => MakeHead(label),
                             fractionDigits: 1,
                         },
@@ -202,7 +202,7 @@ const OverloadedLinesView = (props) => {
                             label: intl.formatMessage({ id: 'Limit' }),
                             dataKey: 'limit',
                             numeric: true,
-                            width: 70,
+                            width: 120,
                             fractionDigits: 1,
                             headerRenderer: ({ label }) => MakeHead(label),
                         },


### PR DESCRIPTION
Widens the overloaded line table to prevent some values from being truncated.

Signed-off-by: BOUTIER Charly <charly.boutier@rte-france.com>