### PR TITLE
Fix RunButtonContainer : runnable to PropTypes.object instead of array.

### DIFF
--- a/src/components/run-button-container.js
+++ b/src/components/run-button-container.js
@@ -350,7 +350,7 @@ export function RunButtonContainer({
 }
 
 RunButtonContainer.propTypes = {
-    runnable: PropTypes.arrayOf(PropTypes.string),
+    runnable: PropTypes.object,
     actionOnRunnable: PropTypes.shape({
         action: PropTypes.func,
         text: PropTypes.string,


### PR DESCRIPTION
Warning: Failed prop type: Invalid prop `runnable` of type `object` supplied to `RunButtonContainer`, expected an array.