### PR TITLE
Fix githubaction node heap out of memory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,14 @@ jobs:
               id: vars
               run: echo ::set-output name=tag::${GITHUB_REF_NAME#v}
 
-            - name: setup NodeJS version
-              uses: actions/setup-node@v3
-              with:
-                node-version: 16.19.0 # fix : version in runner-image ubuntu22/20230206.1
+            # - name: setup NodeJS version
+            #   uses: actions/setup-node@v3
+            #   with:
+            #     node-version: 16.19.0 # fix : version in runner-image ubuntu22/20230206.1
 
             - name: Install and Build
+              env:
+                NODE_OPTIONS: "--max_old_space_size=4096"
               run: |
                   npm install
                   npm run-script build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,6 @@ jobs:
               id: vars
               run: echo ::set-output name=tag::${GITHUB_REF_NAME#v}
 
-            # - name: setup NodeJS version
-            #   uses: actions/setup-node@v3
-            #   with:
-            #     node-version: 16.19.0 # fix : version in runner-image ubuntu22/20230206.1
-
             - name: Install and Build
               env:
                 NODE_OPTIONS: "--max_old_space_size=4096"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
               run: echo ::set-output name=tag::${GITHUB_REF_NAME#v}
 
             - name: Install and Build
+            - uses: actions/setup-node@v3
+              with:
+                node-version: lts/fermium
               run: |
                   npm install
                   npm run-script build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
               run: echo ::set-output name=tag::${GITHUB_REF_NAME#v}
 
             - name: Install and Build
-            - uses: actions/setup-node@v3
+              uses: actions/setup-node@v3
               with:
                 node-version: lts/fermium
               run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,12 @@ jobs:
               id: vars
               run: echo ::set-output name=tag::${GITHUB_REF_NAME#v}
 
-            - name: Install and Build
+            - name: setup NodeJS version
               uses: actions/setup-node@v3
               with:
                 node-version: lts/fermium
+
+            - name: Install and Build
               run: |
                   npm install
                   npm run-script build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
             - name: setup NodeJS version
               uses: actions/setup-node@v3
               with:
-                node-version: lts/fermium
+                node-version: 16.19.0 # fix : version in runner-image ubuntu22/20230206.1
 
             - name: Install and Build
               run: |


### PR DESCRIPTION
since new runner image
cf : https://github.com/actions/runner-images/blob/ubuntu22/20230217.1/images/linux/Ubuntu2204-Readme.md
version : 20230217.1/

Our CI/CD github Action fails sometimes
at npm run build step :

```
<--- Last few GCs --->

[1759:0x6ba0f20]   107119 ms: Mark-sweep 1994.2 (2089.2) -> 1979.8 (2090.7) MB, 2184.9 / 0.0 ms  (average mu = 0.267, current mu = 0.024) allocation failure; scavenge might not succeed
[1759:0x6ba0f20]   109898 ms: Mark-sweep 2000.5 (2096.0) -> 1986.3 (2097.2) MB, 2448.2 / 0.0 ms  (average mu = 0.192, current mu = 0.119) allocation failure; GC in old space requested


<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

should increase our max-old-space-size maybe for Node.js
(https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes)