### PR TITLE
Avoid to destroy result tabs when navigating

### DIFF
--- a/src/components/result-view-tab.js
+++ b/src/components/result-view-tab.js
@@ -21,6 +21,7 @@ import AlertInvalidNode from './util/alert-invalid-node';
 import { PARAM_DEVELOPER_MODE } from '../utils/config-params';
 import { useParameterState } from './dialogs/parameters/parameters';
 import DynamicSimulationResultTab from './results/dynamicsimulation/dynamic-simulation-result-tab';
+import TabPanelLazy from './results/common/tab-panel-lazy';
 
 const useStyles = makeStyles((theme) => ({
     div: {
@@ -171,11 +172,22 @@ export const ResultViewTab = ({
                 </Tabs>
                 {disabled && <AlertInvalidNode />}
             </div>
-            {tabIndex === 0 && !disabled && renderLoadFlowResult()}
-            {tabIndex === 1 && !disabled && renderSecurityAnalysisResult()}
-            {tabIndex === 2 && !disabled && renderShortCircuitAnalysisResult()}
-            {tabIndex === 3 && !disabled && renderSensitivityAnalysisResult()}
-            {tabIndex === 4 && !disabled && renderDynamicSimulationResult()}
+            {/* tab contents */}
+            <TabPanelLazy selected={tabIndex === 0 && !disabled}>
+                {renderLoadFlowResult()}
+            </TabPanelLazy>
+            <TabPanelLazy selected={tabIndex === 1 && !disabled}>
+                {renderSecurityAnalysisResult()}
+            </TabPanelLazy>
+            <TabPanelLazy selected={tabIndex === 2 && !disabled}>
+                {renderShortCircuitAnalysisResult()}
+            </TabPanelLazy>
+            <TabPanelLazy selected={tabIndex === 3 && !disabled}>
+                {renderSensitivityAnalysisResult()}
+            </TabPanelLazy>
+            <TabPanelLazy selected={tabIndex === 4 && !disabled}>
+                {renderDynamicSimulationResult()}
+            </TabPanelLazy>
         </Paper>
     );
 };

--- a/src/components/results/common/tab-panel-lazy.js
+++ b/src/components/results/common/tab-panel-lazy.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import React, { useEffect, useState } from 'react';
+
+const TabPanelLazy = (props) => {
+    const { children, selected, ...other } = props;
+    const [initialized, setInitialized] = useState(false);
+
+    // force mount child once
+    useEffect(() => {
+        if (!initialized && selected) {
+            setInitialized(true);
+        }
+    }, [selected, initialized]);
+
+    return (
+        <div
+            style={{ height: '100%', display: selected ? 'flex' : 'none' }}
+            {...other}
+        >
+            {initialized && children}
+        </div>
+    );
+};
+
+export default TabPanelLazy;


### PR DESCRIPTION
Using a lazy tab panel to force child component mounted once