### PR TITLE
Fix Add defaultMessage prop for Providers label

### DIFF
--- a/src/components/dialogs/parameters/parameters.js
+++ b/src/components/dialogs/parameters/parameters.js
@@ -116,7 +116,10 @@ export const DropDown = ({ value, label, values, callback, renderValue }) => {
                             {renderValue ? (
                                 renderValue(value)
                             ) : (
-                                <FormattedMessage id={value} />
+                                <FormattedMessage
+                                    id={value}
+                                    defaultMessage={value}
+                                />
                             )}
                         </MenuItem>
                     ))}


### PR DESCRIPTION
from MessageDescriptor to define  the direct value when the translation is missing to avoid intlJS Error in console.
see : https://formatjs.io/docs/react-intl/components/#formattedmessage
and : https://github.com/formatjs/formatjs/issues/465

A Warning will remain.