### PR TITLE
Dynamic simulation - lack of translation for fetching errors

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -385,6 +385,13 @@
     "updateSensitivityAnalysisParametersError": "An error occurred while updating the sensitivity analysis parameters",
     "fetchSensitivityAnalysisParametersError": "An error occured when fetching the sensitivity analysis parameters",
 
+    "fetchDynamicSimulationProvidersError": "An error occured when fetching dynamic simulation provider list",
+    "fetchDynamicSimulationProviderError": "An error occured when fetching dynamic simulation provider",
+    "fetchDefaultDynamicSimulationProviderError": "An error occured when fetching default dynamic simulation provider",
+    "updateDynamicSimulationProviderError": "An error occured when updating dynamic simulation provider",
+    "updateDynamicSimulationParametersError": "An error occurred while updating the dynamic simulation parameters",
+    "fetchDynamicSimulationParametersError": "An error occured when fetching the dynamic simulation parameters",
+
     "SubstationList": "Substation list",
     "NetworkModificationTree": "Network modification tree",
     "HybridDisplay": "Hybrid display",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -385,6 +385,13 @@
     "updateSensitivityAnalysisParametersError": "Une erreur est survenue lors de la mise a jour des paramètres de l'analyse de sensibilité",
     "fetchSensitivityAnalysisParametersError": "Une erreur est survenue lors de la récupération des paramètres de l'analyse de sensibilité",
 
+    "fetchDynamicSimulationProvidersError": "Une erreur est survenue lors de la récupération des fournisseurs de simulation dynamique",
+    "fetchDynamicSimulationProviderError": "Une erreur est survenue lors de la récupération du fournisseur courant de simulation dynamique",
+    "fetchDefaultDynamicSimulationProviderError": "Une erreur est survenue lors de la récupération du fournisseur de simulation dynamique par défaut",
+    "updateDynamicSimulationProviderError": "Une erreur est survenue lors de la mise a jour du fournisseur courant de simulation dynamique",
+    "updateDynamicSimulationParametersError": "Une erreur est survenue lors de la mise a jour des paramètres de la simulation dynamique",
+    "fetchDynamicSimulationParametersError": "Une erreur est survenue lors de la récupération des paramètres de la simulation dynamique",
+
     "SubstationList": "Liste des postes",
     "NetworkModificationTree": "Arbre décisionnel",
     "HybridDisplay": "Affichage hybride",


### PR DESCRIPTION
Correction after merge PR : https://github.com/gridsuite/gridstudy-app/pull/1131
In case of error on back, the title of snack bar is not translated as bellow

![image](https://user-images.githubusercontent.com/117309322/231484507-89f87bca-fe29-4248-a1b1-19f1c2f073d4.png)
