### PR TITLE
Rename the variables 'methods' and 'schema' of forms

### DIFF
--- a/src/components/dialogs/parameters/common/wrapper-input.js
+++ b/src/components/dialogs/parameters/common/wrapper-input.js
@@ -16,18 +16,18 @@ import { FormattedMessage } from 'react-intl';
 const WrapperInput = ({ value, label, callback, validator, children }) => {
     const classes = useStyles();
 
-    const schema = yup.object().shape({
+    const formSchema = yup.object().shape({
         value: validator,
     });
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: {
             value: value,
         },
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { handleSubmit, watch } = methods;
+    const { handleSubmit, watch } = formMethods;
 
     // to commit by onChange rather than onSubmit
     useEffect(() => {
@@ -44,7 +44,7 @@ const WrapperInput = ({ value, label, callback, validator, children }) => {
                     </Box>
                 </Typography>
             </Grid>
-            <FormProvider validationSchema={schema} {...methods}>
+            <FormProvider validationSchema={formSchema} {...formMethods}>
                 <Grid item container xs={4} className={classes.controlItem}>
                     {children}
                 </Grid>

--- a/src/components/refactor/dialogs/delete-attaching-line/delete-attaching-line-dialog.js
+++ b/src/components/refactor/dialogs/delete-attaching-line/delete-attaching-line-dialog.js
@@ -30,7 +30,7 @@ const emptyFormData = {
     [REPLACING_LINE_1_NAME]: '',
 };
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         [ATTACHED_LINE_ID]: yup.string().nullable().required(),
@@ -58,12 +58,12 @@ const DeleteAttachingLineDialog = ({
 
     const { snackError } = useSnackMessage();
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     const fromEditDataToFormValues = useCallback(
         (editData) => {
@@ -110,7 +110,7 @@ const DeleteAttachingLineDialog = ({
     }, [reset]);
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 maxWidth="md"

--- a/src/components/refactor/dialogs/delete-voltage-level-on-line/delete-voltage-level-on-line-dialog.js
+++ b/src/components/refactor/dialogs/delete-voltage-level-on-line/delete-voltage-level-on-line-dialog.js
@@ -28,7 +28,7 @@ const emptyFormData = {
     [REPLACING_LINE_1_NAME]: '',
 };
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         [LINE_TO_ATTACH_TO_1_ID]: yup.string().nullable().required(),
@@ -55,12 +55,12 @@ const DeleteVoltageLevelOnLineDialog = ({
 
     const { snackError } = useSnackMessage();
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     const fromEditDataToFormValues = useCallback(
         (editData) => {
@@ -105,7 +105,7 @@ const DeleteVoltageLevelOnLineDialog = ({
     }, [reset]);
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 maxWidth="md"

--- a/src/components/refactor/dialogs/equipment-deletion/equipment-deletion-dialog.js
+++ b/src/components/refactor/dialogs/equipment-deletion/equipment-deletion-dialog.js
@@ -17,7 +17,7 @@ import { EQUIPMENT_TYPES } from '../../../util/equipment-types';
 import DeleteEquipmentForm from './equipment-deletion-form';
 import PropTypes from 'prop-types';
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         [TYPE]: yup.object().nullable().required(),
@@ -47,12 +47,12 @@ const EquipmentDeletionDialog = ({
 
     const { snackError } = useSnackMessage();
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     const fromEditDataToFormValues = useCallback(
         (editData) => {
@@ -96,7 +96,7 @@ const EquipmentDeletionDialog = ({
     }, [reset]);
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 maxWidth="md"

--- a/src/components/refactor/dialogs/generator-scaling/generator-scaling-dialog.js
+++ b/src/components/refactor/dialogs/generator-scaling/generator-scaling-dialog.js
@@ -22,7 +22,7 @@ const emptyFormData = {
     [VARIATIONS]: [],
 };
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         [VARIATION_TYPE]: yup.string().required(),
@@ -39,12 +39,12 @@ const GeneratorScalingDialog = ({
     const currentNodeUuid = currentNode.id;
     const { snackError } = useSnackMessage();
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     useEffect(() => {
         if (editData) {
@@ -78,7 +78,7 @@ const GeneratorScalingDialog = ({
     );
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 onClear={clear}

--- a/src/components/refactor/dialogs/generator/creation/generator-creation-dialog.js
+++ b/src/components/refactor/dialogs/generator/creation/generator-creation-dialog.js
@@ -89,7 +89,7 @@ const emptyFormData = {
     ...getConnectivityWithPositionEmptyFormData(),
 };
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape(
         {
@@ -139,12 +139,12 @@ const GeneratorCreationDialog = ({
 
     const equipmentPath = 'generators';
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
     const fromSearchCopyToFormValues = (generator) => {
         reset({
             [EQUIPMENT_ID]: generator.id + '(1)',
@@ -330,7 +330,7 @@ const GeneratorCreationDialog = ({
     );
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 onClear={clear}

--- a/src/components/refactor/dialogs/generator/modification/generator-modification-dialog.js
+++ b/src/components/refactor/dialogs/generator/modification/generator-modification-dialog.js
@@ -241,12 +241,12 @@ const GeneratorModificationDialog = ({
         []
     );
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: defaultFormData,
         resolver: yupResolver(schema),
     });
 
-    const { reset, getValues, setValue } = methods;
+    const { reset, getValues, setValue } = formMethods;
 
     //this method empties the form, and let us pass custom data that we want to set
     const setValuesAndEmptyOthers = useCallback(
@@ -544,7 +544,7 @@ const GeneratorModificationDialog = ({
         <FormProvider
             validationSchema={schema}
             removeOptional={true}
-            {...methods}
+            {...formMethods}
         >
             <ModificationDialog
                 fullWidth

--- a/src/components/refactor/dialogs/line-attach-to-voltage-level/line-attach-to-voltage-level-dialog.js
+++ b/src/components/refactor/dialogs/line-attach-to-voltage-level/line-attach-to-voltage-level-dialog.js
@@ -54,7 +54,7 @@ const emptyFormData = {
     ...getConnectivityWithoutPositionEmptyFormData(),
 };
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         [ATTACHMENT_LINE_ID]: yup.string().required(),
@@ -90,12 +90,12 @@ const LineAttachToVoltageLevelDialog = ({
 
     const { snackError } = useSnackMessage();
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset, getValues, setValue } = methods;
+    const { reset, getValues, setValue } = formMethods;
 
     const fromEditDataToFormValues = useCallback(
         (lineAttach) => {
@@ -295,7 +295,7 @@ const LineAttachToVoltageLevelDialog = ({
     }, [getValues, newVoltageLevel]);
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 maxWidth="md"

--- a/src/components/refactor/dialogs/line-creation/line-creation-dialog.js
+++ b/src/components/refactor/dialogs/line-creation/line-creation-dialog.js
@@ -111,7 +111,7 @@ const LineCreationDialog = ({
     const [tabIndexesWithError, setTabIndexesWithError] = useState([]);
     const [voltageLevelOptions, setVoltageLevelOptions] = useState([]);
 
-    const schema = yup
+    const formSchema = yup
         .object()
         .shape({
             ...getHeaderValidationSchema(),
@@ -123,12 +123,12 @@ const LineCreationDialog = ({
         })
         .required();
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     const fromSearchCopyToFormValues = (line) => {
         reset(
@@ -366,7 +366,7 @@ const LineCreationDialog = ({
     );
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 onClear={clear}

--- a/src/components/refactor/dialogs/line-split-with-voltage-level/line-split-with-voltage-level-dialog.js
+++ b/src/components/refactor/dialogs/line-split-with-voltage-level/line-split-with-voltage-level-dialog.js
@@ -48,7 +48,7 @@ const emptyFormData = {
     ...getConnectivityWithoutPositionEmptyFormData(),
 };
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         [LINE1_ID]: yup.string().required(),
@@ -79,12 +79,12 @@ const LineSplitWithVoltageLevelDialog = ({
 
     const { snackError } = useSnackMessage();
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset, getValues, setValue } = methods;
+    const { reset, getValues, setValue } = formMethods;
 
     const fromEditDataToFormValues = useCallback(
         (lineSplit) => {
@@ -219,7 +219,7 @@ const LineSplitWithVoltageLevelDialog = ({
     }, [getValues, newVoltageLevel]);
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 maxWidth="md"

--- a/src/components/refactor/dialogs/lines-attach-to-split-lines/lines-attach-to-split-lines-dialog.js
+++ b/src/components/refactor/dialogs/lines-attach-to-split-lines/lines-attach-to-split-lines-dialog.js
@@ -48,7 +48,7 @@ const emptyFormData = {
     ...getConnectivityWithoutPositionEmptyFormData(),
 };
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         [LINE_TO_ATTACH_TO_1_ID]: yup.string().nullable().required(),
@@ -78,12 +78,12 @@ const LinesAttachToSplitLinesDialog = ({
     const currentNodeUuid = currentNode?.id;
     const { snackError } = useSnackMessage();
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     useEffect(() => {
         if (editData) {
@@ -135,7 +135,7 @@ const LinesAttachToSplitLinesDialog = ({
     }, [reset]);
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 onClear={clear}

--- a/src/components/refactor/dialogs/load-creation/load-creation-dialog.js
+++ b/src/components/refactor/dialogs/load-creation/load-creation-dialog.js
@@ -52,7 +52,7 @@ const emptyFormData = {
     ...getConnectivityWithPositionEmptyFormData(),
 };
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         [EQUIPMENT_ID]: yup.string().required(),
@@ -75,12 +75,12 @@ const LoadCreationDialog = ({
 
     const equipmentPath = 'loads';
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     const fromSearchCopyToFormValues = (load) => {
         fetchEquipmentInfos(
@@ -206,7 +206,7 @@ const LoadCreationDialog = ({
     }, [reset]);
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 onClear={clear}

--- a/src/components/refactor/dialogs/load-modification/load-modification-dialog.js
+++ b/src/components/refactor/dialogs/load-modification/load-modification-dialog.js
@@ -32,7 +32,7 @@ import LoadModificationForm from './load-modification-form';
  * @param dialogProps props that are forwarded to the generic ModificationDialog component
  */
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         [EQUIPMENT_ID]: yup.string().nullable().required(),
@@ -64,12 +64,12 @@ const LoadModificationDialog = ({
         [defaultIdValue]
     );
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     const fromEditDataToFormValues = useCallback(
         (load) => {
@@ -121,9 +121,9 @@ const LoadModificationDialog = ({
 
     return (
         <FormProvider
-            validationSchema={schema}
+            validationSchema={formSchema}
             removeOptional={true}
-            {...methods}
+            {...formMethods}
         >
             <ModificationDialog
                 fullWidth

--- a/src/components/refactor/dialogs/load-scaling/load-scaling-dialog.js
+++ b/src/components/refactor/dialogs/load-scaling/load-scaling-dialog.js
@@ -22,7 +22,7 @@ const emptyFormData = {
     [VARIATIONS]: [],
 };
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         [VARIATION_TYPE]: yup.string().required(),
@@ -39,12 +39,12 @@ const LoadScalingDialog = ({
     const currentNodeUuid = currentNode.id;
     const { snackError } = useSnackMessage();
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     useEffect(() => {
         if (editData) {
@@ -78,7 +78,7 @@ const LoadScalingDialog = ({
     );
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 onClear={clear}

--- a/src/components/refactor/dialogs/shunt-compensator-creation/shunt-compensator-creation-dialog.js
+++ b/src/components/refactor/dialogs/shunt-compensator-creation/shunt-compensator-creation-dialog.js
@@ -53,7 +53,7 @@ const emptyFormData = {
     ...getCharacteristicsEmptyFormData(),
 };
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         [EQUIPMENT_ID]: yup.string().required(),
@@ -81,12 +81,12 @@ const ShuntCompensatorCreationDialog = ({
 
     const { snackError } = useSnackMessage();
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     const fromSearchCopyToFormValues = useCallback(
         (shuntCompensator) => {
@@ -191,7 +191,7 @@ const ShuntCompensatorCreationDialog = ({
     }, [reset]);
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 maxWidth="md"

--- a/src/components/refactor/dialogs/substation-creation/substation-creation-dialog.js
+++ b/src/components/refactor/dialogs/substation-creation/substation-creation-dialog.js
@@ -32,7 +32,7 @@ const emptyFormData = {
     [EQUIPMENT_NAME]: '',
     [COUNTRY]: null,
 };
-const schema = yup.object().shape({
+const formSchema = yup.object().shape({
     [EQUIPMENT_ID]: yup.string().required(),
     [EQUIPMENT_NAME]: yup.string(),
     [COUNTRY]: yup.string().nullable(),
@@ -57,12 +57,12 @@ const SubstationCreationDialog = ({
 
     const equipmentPath = 'substations';
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     const fromSearchCopyToFormValues = (substation) => {
         reset(
@@ -120,7 +120,7 @@ const SubstationCreationDialog = ({
         [currentNodeUuid, editData, snackError, studyUuid]
     );
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 onClear={clear}

--- a/src/components/refactor/dialogs/two-windings-transformer-creation/tap-changer-pane/create-rule/create-rule-dialog.js
+++ b/src/components/refactor/dialogs/two-windings-transformer-creation/tap-changer-pane/create-rule/create-rule-dialog.js
@@ -23,7 +23,7 @@ const emptyFormData = getCreateRuteEmptyFormData();
 const schema = getCreateRuleValidationSchema();
 
 export const CreateRuleDialog = (props) => {
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
         resolver: yupResolver(schema),
     });
@@ -34,7 +34,7 @@ export const CreateRuleDialog = (props) => {
         setOpenCreateRuleDialog,
     } = props;
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     const handleCloseDialog = () => {
         reset(emptyFormData);
@@ -48,7 +48,7 @@ export const CreateRuleDialog = (props) => {
 
     return (
         <Dialog open={props.openCreateRuleDialog} fullWidth={true}>
-            <FormProvider validationSchema={schema} {...methods}>
+            <FormProvider validationSchema={schema} {...formMethods}>
                 <CreateRuleForm {...props} />
                 <DialogActions>
                     <Button onClick={handleCloseDialog}>

--- a/src/components/refactor/dialogs/two-windings-transformer-creation/two-windings-transformer-creation-dialog.js
+++ b/src/components/refactor/dialogs/two-windings-transformer-creation/two-windings-transformer-creation-dialog.js
@@ -125,7 +125,7 @@ const emptyFormData = {
     ...getPhaseTapChangerEmptyFormData(),
 };
 
-const schema = yup
+const formSchema = yup
     .object()
     .shape({
         ...getTwoWindingsTransformerValidationSchema(),
@@ -156,12 +156,12 @@ const TwoWindingsTransformerCreationDialog = ({
 
     const equipmentPath = '2-windings-transformers';
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     const [tabIndex, setTabIndex] = useState(
         TwoWindingsTransformerCreationDialogTab.CHARACTERISTICS_TAB
@@ -778,7 +778,7 @@ const TwoWindingsTransformerCreationDialog = ({
     }, [reset]);
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 onClear={clear}

--- a/src/components/refactor/dialogs/voltage-level-creation/switches-between-sections/create-switches-between-sections/create-switches-dialog.js
+++ b/src/components/refactor/dialogs/voltage-level-creation/switches-between-sections/create-switches-between-sections/create-switches-dialog.js
@@ -19,16 +19,16 @@ import { SWITCH_KINDS } from 'components/refactor/utils/field-constants';
 import yup from 'components/refactor/utils/yup-config';
 import { useEffect } from 'react';
 
-const schema = yup.object().shape({
+const formSchema = yup.object().shape({
     ...getCreateSwitchesValidationSchema(),
 });
 
 export const CreateSwitchesDialog = (props) => {
     const sectionCount = props.sectionCount;
     const emptyFormData = getCreateSwitchesEmptyFormData(sectionCount);
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
     const {
         handleCreateSwitchesDialog,
@@ -37,7 +37,7 @@ export const CreateSwitchesDialog = (props) => {
         switchKinds,
     } = props;
 
-    const { reset } = methods;
+    const { reset } = formMethods;
 
     useEffect(() => {
         if (switchKinds?.length > 0) {
@@ -59,7 +59,7 @@ export const CreateSwitchesDialog = (props) => {
 
     return (
         <Dialog open={openCreateSwitchesDialog} fullWidth={true}>
-            <FormProvider validationSchema={schema} {...methods}>
+            <FormProvider validationSchema={formSchema} {...formMethods}>
                 <CreateSwitchesForm id={SWITCH_KINDS} />
                 <DialogActions>
                     <Button onClick={handleCloseDialog}>

--- a/src/components/refactor/dialogs/voltage-level-creation/voltage-level-creation-dialog.js
+++ b/src/components/refactor/dialogs/voltage-level-creation/voltage-level-creation-dialog.js
@@ -68,7 +68,7 @@ const emptyFormData = {
     [SWITCH_KINDS]: [],
 };
 
-const schema = yup.object().shape({
+const formSchema = yup.object().shape({
     [EQUIPMENT_ID]: yup.string().required(),
     [EQUIPMENT_NAME]: yup.string().nullable(),
     [SUBSTATION_ID]: yup.string().nullable().required(),
@@ -113,12 +113,12 @@ const VoltageLevelCreationDialog = ({
     const { snackError, snackWarning } = useSnackMessage();
     const equipmentPath = 'voltage-levels';
 
-    const methods = useForm({
+    const formMethods = useForm({
         defaultValues: emptyFormData,
-        resolver: yupResolver(schema),
+        resolver: yupResolver(formSchema),
     });
 
-    const { reset } = methods;
+    const { reset } = formMethods;
     const intl = useIntl();
 
     const fromExternalDataToFormValues = useCallback(
@@ -215,7 +215,7 @@ const VoltageLevelCreationDialog = ({
     }, [reset]);
 
     return (
-        <FormProvider validationSchema={schema} {...methods}>
+        <FormProvider validationSchema={formSchema} {...formMethods}>
             <ModificationDialog
                 fullWidth
                 onClear={clear}


### PR DESCRIPTION
Rename the variables 'methods' from react-hook-form and 'schema' from yup into 'formMethods' and 'formSchema'