### PR TITLE
Fix Control the effect in SpecificLoadFlowParameters 

### DIFF
--- a/src/components/dialogs/parameters/load-flow-parameters.js
+++ b/src/components/dialogs/parameters/load-flow-parameters.js
@@ -344,7 +344,7 @@ const SpecificLoadFlowParameters = ({
             ...defaultValues,
             ...lfParamsRef.current,
         });
-    }, [currentProvider, defaultValues]);
+    }, [defaultValues]);
 
     const onChange = useCallback(
         (paramName, value, isEdit) => {

--- a/src/components/dialogs/parameters/load-flow-parameters.js
+++ b/src/components/dialogs/parameters/load-flow-parameters.js
@@ -5,7 +5,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Grid, Autocomplete, TextField, Chip, Button } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -328,12 +334,17 @@ const SpecificLoadFlowParameters = ({
         return extractDefaultMap(specificParamsDescription);
     }, [specificParamsDescription]);
 
+    const lfParamsRef = useRef();
+    lfParamsRef.current =
+        lfParams?.specificParametersPerProvider?.[currentProvider];
+
+    // When provider changes or defaultValues then we must reset currentParameters state
     useEffect(() => {
         setCurrentParameters({
             ...defaultValues,
-            ...lfParams?.specificParametersPerProvider?.[currentProvider],
+            ...lfParamsRef.current,
         });
-    }, [lfParams, currentProvider, defaultValues]);
+    }, [currentProvider, defaultValues]);
 
     const onChange = useCallback(
         (paramName, value, isEdit) => {


### PR DESCRIPTION
to update parameters when `provider` and `defaultValues` changes but not when `lfParams` changes otherwise you enter a loop of `setCurrentParameters` calls