### PR TITLE
Dynamic Simulation - Parameters - Remove debounce at low level

### DIFF
--- a/src/components/dialogs/parameters/dynamicsimulation/network-parameters.js
+++ b/src/components/dialogs/parameters/dynamicsimulation/network-parameters.js
@@ -5,8 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { useCallback, useMemo } from 'react';
-import { debounce, Grid } from '@mui/material';
+import { useCallback } from 'react';
+import { Grid } from '@mui/material';
 import { makeComponentsFor, TYPES } from '../util/make-component-utils';
 
 const NetworkParameters = ({ network, onUpdateNetwork }) => {
@@ -15,11 +15,6 @@ const NetworkParameters = ({ network, onUpdateNetwork }) => {
             onUpdateNetwork(newNetwork);
         },
         [onUpdateNetwork]
-    );
-
-    const delayedHandleUpdateNetwork = useMemo(
-        () => debounce(handleUpdateNetwork, 500),
-        [handleUpdateNetwork]
     );
 
     const defParams = {
@@ -111,11 +106,7 @@ const NetworkParameters = ({ network, onUpdateNetwork }) => {
     return (
         network && (
             <Grid container>
-                {makeComponentsFor(
-                    defParams,
-                    network,
-                    delayedHandleUpdateNetwork
-                )}
+                {makeComponentsFor(defParams, network, handleUpdateNetwork)}
             </Grid>
         )
     );

--- a/src/components/dialogs/parameters/dynamicsimulation/solver/ida-solver-parameters.js
+++ b/src/components/dialogs/parameters/dynamicsimulation/solver/ida-solver-parameters.js
@@ -6,8 +6,7 @@
  */
 
 import { makeComponentsFor, TYPES } from '../../util/make-component-utils';
-import { useCallback, useMemo } from 'react';
-import { debounce } from '@mui/material';
+import { useCallback } from 'react';
 
 const IdaSolverParameters = ({ idaSolver, onUpdateIdaSolver }) => {
     const defParams = {
@@ -44,19 +43,8 @@ const IdaSolverParameters = ({ idaSolver, onUpdateIdaSolver }) => {
         [onUpdateIdaSolver]
     );
 
-    const delayedHandleUpdateIdaSolver = useMemo(
-        () => debounce(handleUpdateIdaSolver, 500),
-        [handleUpdateIdaSolver]
-    );
-
     return (
-        <>
-            {makeComponentsFor(
-                defParams,
-                idaSolver,
-                delayedHandleUpdateIdaSolver
-            )}
-        </>
+        <>{makeComponentsFor(defParams, idaSolver, handleUpdateIdaSolver)}</>
     );
 };
 

--- a/src/components/dialogs/parameters/dynamicsimulation/solver/simplified-solver-parameters.js
+++ b/src/components/dialogs/parameters/dynamicsimulation/solver/simplified-solver-parameters.js
@@ -6,8 +6,7 @@
  */
 
 import { makeComponentsFor, TYPES } from '../../util/make-component-utils';
-import { useCallback, useMemo } from 'react';
-import { debounce } from '@mui/material';
+import { useCallback } from 'react';
 
 const SimplifiedSolverParameters = ({
     simplifiedSolver,
@@ -55,17 +54,12 @@ const SimplifiedSolverParameters = ({
         [onUpdateSimplifiedSolver]
     );
 
-    const delayedHandleUpdateSimplifiedSolver = useMemo(
-        () => debounce(handleUpdateSimplifiedSolver, 500),
-        [handleUpdateSimplifiedSolver]
-    );
-
     return (
         <>
             {makeComponentsFor(
                 defParams,
                 simplifiedSolver,
-                delayedHandleUpdateSimplifiedSolver
+                handleUpdateSimplifiedSolver
             )}
         </>
     );

--- a/src/components/dialogs/parameters/dynamicsimulation/time-delay-parameters.js
+++ b/src/components/dialogs/parameters/dynamicsimulation/time-delay-parameters.js
@@ -5,9 +5,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { debounce, Grid } from '@mui/material';
+import { Grid } from '@mui/material';
 import { makeComponentsFor, TYPES } from '../util/make-component-utils';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 const TimeDelayParameters = ({ timeDelay, onUpdateTimeDelay }) => {
     const handleUpdateTimeDelay = useCallback(
@@ -15,11 +15,6 @@ const TimeDelayParameters = ({ timeDelay, onUpdateTimeDelay }) => {
             onUpdateTimeDelay(newTimeDelay);
         },
         [onUpdateTimeDelay]
-    );
-
-    const delayedHandleUpdateTimeDelay = useMemo(
-        () => debounce(handleUpdateTimeDelay, 500),
-        [handleUpdateTimeDelay]
     );
 
     const defParams = {
@@ -35,11 +30,7 @@ const TimeDelayParameters = ({ timeDelay, onUpdateTimeDelay }) => {
     return (
         timeDelay && (
             <Grid container>
-                {makeComponentsFor(
-                    defParams,
-                    timeDelay,
-                    delayedHandleUpdateTimeDelay
-                )}
+                {makeComponentsFor(defParams, timeDelay, handleUpdateTimeDelay)}
             </Grid>
         )
     );


### PR DESCRIPTION
Remove the redundant debounces in dynamic simulation parameters after merging PR: https://github.com/gridsuite/gridstudy-app/pull/1274
which generally manages debounce in the hook : useParametersBackend 