### PR TITLE
Fix warning in ModificationDialog

### DIFF
--- a/src/components/dialogs/commons/modificationDialog.js
+++ b/src/components/dialogs/commons/modificationDialog.js
@@ -59,8 +59,6 @@ const ModificationDialog = ({
         <ModificationDialogContent
             submitButton={submitButton}
             closeAndClear={closeAndClear}
-            onValidated={onValidated}
-            onValidationError={onValidationError}
             {...props}
         />
     );


### PR DESCRIPTION
Remove useless props use in ModificationDialogContent

Warning: Unknown event handler property `onValidationError`. It will be ignored.
Warning: Unknown event handler property `onValidated`. It will be ignored.