### PR TITLE
Stops the silent renew from hiding the parameters dialog

### DIFF
--- a/src/components/app-top-bar.js
+++ b/src/components/app-top-bar.js
@@ -270,7 +270,6 @@ const AppTopBar = ({ user, tabIndex, onChangeTab, userManager }) => {
                 setAppsAndUrls(res);
             });
         }
-        hideParameters();
     }, [user]);
 
     useEffect(() => {
@@ -473,11 +472,13 @@ const AppTopBar = ({ user, tabIndex, onChangeTab, userManager }) => {
                     </Tabs>
                 )}
             </TopBar>
-            <Parameters
-                isParametersOpen={isParametersOpen}
-                hideParameters={hideParameters}
-                user={user}
-            />
+            {studyUuid && (
+                <Parameters
+                    isParametersOpen={isParametersOpen}
+                    hideParameters={hideParameters}
+                    user={user}
+                />
+            )}
         </>
     );
 };


### PR DESCRIPTION
Stops the silent renew from hiding the parameters dialog, and hide the parameters dialog when the user is logged out.