### PR TITLE
Remove a console error when a Diagram is put in fullscreen

### DIFF
--- a/src/components/diagrams/diagram.js
+++ b/src/components/diagrams/diagram.js
@@ -106,7 +106,7 @@ const Diagram = (props) => {
             height={shouldBeFullscreen ? props.fullscreenHeight : props.height}
             width={shouldBeFullscreen ? props.fullscreenWidth : props.width}
             // We disable the resizeBox if a diagram is in fullscreen
-            disableResize={fullScreenDiagram?.id}
+            disableResize={!!fullScreenDiagram?.id}
             // We hide this diagram if another diagram is in fullscreen mode.
             hide={shouldBeHidden}
         >


### PR DESCRIPTION
Fixes the disableResize props type to remove a console error in the Diagrams when setting one fullscreen.