### PR TITLE
Auto-Scroll to Error Messages on Long Forms

### DIFF
--- a/src/components/utils/rhf-inputs/error-inputs/error-input.js
+++ b/src/components/utils/rhf-inputs/error-inputs/error-input.js
@@ -18,7 +18,7 @@ const ErrorInput = ({ name, InputField }) => {
 
     const { isSubmitted } = useFormState();
 
-    const errorRef = useRef(null); 
+    const errorRef = useRef(null);
 
     const errorProps = (errorMsg) => {
         if (typeof errorMsg === 'string') {
@@ -40,16 +40,20 @@ const ErrorInput = ({ name, InputField }) => {
         if (isSubmitted && error && errorRef?.current) {
             errorRef.current.scrollIntoView({ behavior: 'smooth' });
         }
-    }, [isSubmitted]);
+    }, [error, isSubmitted]);
 
     return (
-        error?.message && (
-            <div ref={errorRef}>
-                <InputField
-                    message={<FormattedMessage {...errorProps(error?.message)} />}
-                />
-            </div>
-        )
+        <>
+            {error?.message && (
+                <div ref={errorRef}>
+                    <InputField
+                        message={
+                            <FormattedMessage {...errorProps(error?.message)} />
+                        }
+                    />
+                </div>
+            )}
+        </>
     );
 };
 

--- a/src/components/utils/rhf-inputs/error-inputs/error-input.js
+++ b/src/components/utils/rhf-inputs/error-inputs/error-input.js
@@ -12,7 +12,7 @@ import React, { useEffect, useRef } from 'react';
 const ErrorInput = ({ name, InputField }) => {
     const {
         fieldState: { error },
-        formState: { isSubmitted },
+        formState: { isSubmitting },
     } = useController({
         name,
     });
@@ -36,10 +36,12 @@ const ErrorInput = ({ name, InputField }) => {
     };
 
     useEffect(() => {
-        if (isSubmitted && error && errorRef?.current) {
+        // the scroll should be done only when the form is submitting
+        if (error && errorRef.current) {
             errorRef.current.scrollIntoView({ behavior: 'smooth' });
         }
-    }, [error, isSubmitted]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isSubmitting]);
 
     return (
         <>

--- a/src/components/utils/rhf-inputs/error-inputs/error-input.js
+++ b/src/components/utils/rhf-inputs/error-inputs/error-input.js
@@ -5,9 +5,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { useController } from 'react-hook-form';
+import { useController, useFormState } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 const ErrorInput = ({ name, InputField }) => {
     const {
@@ -15,6 +15,10 @@ const ErrorInput = ({ name, InputField }) => {
     } = useController({
         name,
     });
+
+    const { isSubmitted } = useFormState();
+
+    const errorRef = useRef(null); 
 
     const errorProps = (errorMsg) => {
         if (typeof errorMsg === 'string') {
@@ -32,11 +36,19 @@ const ErrorInput = ({ name, InputField }) => {
         return {};
     };
 
+    useEffect(() => {
+        if (isSubmitted && error && errorRef?.current) {
+            errorRef.current.scrollIntoView({ behavior: 'smooth' });
+        }
+    }, [isSubmitted]);
+
     return (
         error?.message && (
-            <InputField
-                message={<FormattedMessage {...errorProps(error?.message)} />}
-            />
+            <div ref={errorRef}>
+                <InputField
+                    message={<FormattedMessage {...errorProps(error?.message)} />}
+                />
+            </div>
         )
     );
 };

--- a/src/components/utils/rhf-inputs/error-inputs/error-input.js
+++ b/src/components/utils/rhf-inputs/error-inputs/error-input.js
@@ -5,18 +5,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { useController, useFormState } from 'react-hook-form';
+import { useController } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';
 import React, { useEffect, useRef } from 'react';
 
 const ErrorInput = ({ name, InputField }) => {
     const {
         fieldState: { error },
+        formState: { isSubmitted },
     } = useController({
         name,
     });
-
-    const { isSubmitted } = useFormState();
 
     const errorRef = useRef(null);
 


### PR DESCRIPTION
Previously, when users submitted a form and there was an error message generated at the bottom, it wasn't immediately visible due to the form's length.
To enhance the user experience, I've implemented an auto-scroll feature. 