### PR TITLE
Dynamic Simulation: add scrollbar to curve selection dialog

### DIFF
--- a/src/components/dialogs/parameters/dynamicsimulation/curve-parameters.js
+++ b/src/components/dialogs/parameters/dynamicsimulation/curve-parameters.js
@@ -11,10 +11,10 @@ import 'ag-grid-community/styles/ag-theme-alpine.css';
 import { Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import GridButtons from './curve/grid-buttons';
-import { AgGridReact } from 'ag-grid-react';
 import { useIntl } from 'react-intl';
 import CurveSelectorDialog from './curve/dialog/curve-selector-dialog';
 import { GlobalFilter } from '../../../spreadsheet/global-filter';
+import { CustomAGGrid } from '../../../custom-aggrid/custom-aggrid';
 import { Box } from '@mui/system';
 
 const styles = {
@@ -63,14 +63,14 @@ const CurveParameters = ({ curves, onUpdateCurve }) => {
         return [
             {
                 field: 'equipmentId',
-                minWidth: '80',
+                minWidth: 80,
                 headerName: intl.formatMessage({
                     id: 'DynamicSimulationCurveDynamicModelHeader',
                 }),
             },
             {
                 field: 'variableId',
-                minWidth: '80',
+                minWidth: 80,
                 headerName: intl.formatMessage({
                     id: 'DynamicSimulationCurveVariableHeader',
                 }),
@@ -167,8 +167,8 @@ const CurveParameters = ({ curves, onUpdateCurve }) => {
                     </Grid>
                     {/* aggrid for configured curves */}
                     <Grid item xs>
-                        <Box sx={styles.grid} className={theme.aggrid}>
-                            <AgGridReact
+                        <Box sx={styles.grid}>
+                            <CustomAGGrid
                                 ref={gridRef}
                                 rowData={rowData}
                                 columnDefs={columnDefs}
@@ -176,7 +176,7 @@ const CurveParameters = ({ curves, onUpdateCurve }) => {
                                 rowSelection={'multiple'}
                                 onGridReady={onGridReady}
                                 onSelectionChanged={onSelectionChanged}
-                            ></AgGridReact>
+                            ></CustomAGGrid>
                         </Box>
                     </Grid>
                 </Grid>

--- a/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/curve-preview.js
+++ b/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/curve-preview.js
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { AgGridReact } from 'ag-grid-react';
 import React, {
     forwardRef,
     useCallback,
@@ -15,8 +14,9 @@ import React, {
     useState,
 } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Grid, Typography, useTheme } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import { Box } from '@mui/system';
+import { CustomAGGrid } from '../../../../../custom-aggrid/custom-aggrid';
 
 const styles = {
     grid: {
@@ -30,7 +30,6 @@ const styles = {
 
 const CurvePreview = forwardRef((props, ref) => {
     const intl = useIntl();
-    const theme = useTheme();
     const gridRef = useRef();
 
     const [rowData, setRowData] = useState([]);
@@ -39,14 +38,14 @@ const CurvePreview = forwardRef((props, ref) => {
         return [
             {
                 field: 'equipmentId',
-                minWidth: '80',
+                minWidth: 80,
                 headerName: intl.formatMessage({
                     id: 'DynamicSimulationCurveDynamicModelHeader',
                 }),
             },
             {
                 field: 'variableId',
-                minWidth: '80',
+                minWidth: 80,
                 headerName: intl.formatMessage({
                     id: 'DynamicSimulationCurveVariableHeader',
                 }),
@@ -129,15 +128,15 @@ const CurvePreview = forwardRef((props, ref) => {
                 </Typography>
             </Grid>
             <Grid xs>
-                <Box sx={styles.grid} className={theme.aggrid}>
-                    <AgGridReact
+                <Box sx={styles.grid}>
+                    <CustomAGGrid
                         ref={gridRef}
                         rowData={rowData}
                         columnDefs={columnDefs}
                         defaultColDef={defaultColDef}
                         rowSelection={'multiple'}
                         onSelectionChanged={onSelectionChanged}
-                    ></AgGridReact>
+                    ></CustomAGGrid>
                 </Box>
             </Grid>
         </>

--- a/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/curve-selector-dialog.js
+++ b/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/curve-selector-dialog.js
@@ -24,6 +24,7 @@ import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import ArrowCircleRightIcon from '@mui/icons-material/ArrowCircleRight';
 import ArrowCircleLeftIcon from '@mui/icons-material/ArrowCircleLeft';
+import { mergeSx } from '../../../../../utils/functions';
 
 const CurveSelectorDialog = ({ open, onClose, onSave }) => {
     const theme = useTheme();
@@ -84,7 +85,13 @@ const CurveSelectorDialog = ({ open, onClose, onSave }) => {
                 </Typography>
             </DialogTitle>
             <DialogContent style={{ overflowY: 'hidden', height: '60vh' }}>
-                <Grid container maxWidth={'xl'} sx={{ height: '100%' }}>
+                <Grid
+                    container
+                    sx={mergeSx(styles.scrollableGrid, {
+                        maxWidth: 'xl',
+                        height: '100%',
+                    })}
+                >
                     <Grid item container xs={8} spacing={theme.spacing(1)}>
                         <CurveSelector ref={selectorRef} />
                     </Grid>

--- a/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/equipment-filter.js
+++ b/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/equipment-filter.js
@@ -16,7 +16,6 @@ import React, {
     useRef,
     useState,
 } from 'react';
-import { AgGridReact } from 'ag-grid-react';
 import CountrySelect from '../country-select';
 import CheckboxSelect from '../common/checkbox-select';
 import { useSelector } from 'react-redux';
@@ -24,6 +23,7 @@ import { useSnackMessage } from '@gridsuite/commons-ui';
 import { EQUIPMENT_TYPES } from '../../../../../utils/equipment-types';
 import { EQUIPMENT_FETCHERS } from 'components/utils/equipment-fetchers';
 import { Box } from '@mui/system';
+import { CustomAGGrid } from '../../../../../custom-aggrid/custom-aggrid';
 
 export const CURVE_EQUIPMENTS = {
     [EQUIPMENT_TYPES.GENERATOR]: {
@@ -304,7 +304,7 @@ const EquipmentFilter = forwardRef(
                     checkboxSelection: true,
                     headerCheckboxSelection: true,
                     headerCheckboxSelectionFilteredOnly: true,
-                    minWidth: '80',
+                    minWidth: 80,
                     headerName: intl.formatMessage({
                         id: 'DynamicSimulationCurveDynamicModelHeader',
                     }),
@@ -452,8 +452,8 @@ const EquipmentFilter = forwardRef(
                         </Typography>
                     </Grid>
                     <Grid xs>
-                        <Box sx={styles.grid} className={theme.aggrid}>
-                            <AgGridReact
+                        <Box sx={styles.grid}>
+                            <CustomAGGrid
                                 ref={equipmentsRef}
                                 rowData={equipmentRowData}
                                 columnDefs={columnDefs}
@@ -463,7 +463,7 @@ const EquipmentFilter = forwardRef(
                                 onSelectionChanged={
                                     handleEquipmentSelectionChanged
                                 }
-                            ></AgGridReact>
+                            ></CustomAGGrid>
                         </Box>
                     </Grid>
                 </Grid>

--- a/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/model-filter.js
+++ b/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/model-filter.js
@@ -232,13 +232,13 @@ const ModelFilter = forwardRef(({ equipment = CURVE_EQUIPMENTS.LOAD }, ref) => {
                     </Typography>
                 </Grid>
                 <Grid xs>
-                    <Box sx={styles.grid} className={theme.aggrid}>
+                    <Box sx={styles.grid}>
                         <CheckboxTreeview
                             ref={variablesRef}
                             data={filteredVariables}
                             checkAll
                             sx={{
-                                maxHeight: '460px',
+                                maxHeight: '440px',
                                 maxWidth: '50px',
                             }}
                         />


### PR DESCRIPTION
**Bug found by Charly during the emotion migration** => when expand the variable tree box, a partial content at the bottom is hidden. Note that the bug is only produced if reducing the size of the global window, cf demo

![curve_before_hidden_when_expand_model](https://github.com/gridsuite/gridstudy-app/assets/117309322/af1497b5-1a88-4a74-8a18-1197fe51d3b8)

**Solution**: add a scrollbar to the dialogue, see demo after fix

![curve_after_scrollbar_](https://github.com/gridsuite/gridstudy-app/assets/117309322/d1aafd5d-7d9a-4a0a-881f-16bb6ff10f08)

**Bonus**: In this PR, switch to CustomAGGrid for some tables in the curve configuration..