### PR TITLE
Fix arrow offset

### DIFF
--- a/src/components/network/layers/arrow-layer-vertex.glsl.js
+++ b/src/components/network/layers/arrow-layer-vertex.glsl.js
@@ -131,7 +131,7 @@ mat3 calculateRotation(vec3 commonPosition1, vec3 commonPosition2) {
 // Adjustment factor for low zoom levels
 float project_size_at_latitude(float lat) {
   float y = clamp(lat, -89.9, 89.9);
-  return 1.0 / cos(radians(y)); // can't use Taylor series here
+  return 1.0 / cos(radians(y));
 }
 
 /**
@@ -140,7 +140,6 @@ float project_size_at_latitude(float lat) {
 float project_size_at_latitude(float meters, float lat) {
   return meters * project_uCommonUnitsPerMeter.z * project_size_at_latitude(lat);
 }
-
 
 void main(void) {
   if (instanceArrowDirection < 1.0) {
@@ -173,8 +172,8 @@ void main(void) {
       vec3 commonPosition1 = project_position(linePosition1, position64Low);
       vec3 commonPosition2 = project_position(linePosition2, position64Low);
 
-      // calculate offset in the common space using arrow latitude in worldspace to increase precision.
-      // Projecting at latitudes geometry.worldSpace.y or geometry.position.y as in project_size() introduces an offset at certain zoom levels.
+      // project offset in the common space using arrow latitude in worldspace to increase precision.
+      // Projecting with latitudes geometry.worldSpace.y or geometry.position.y as in project_size() introduces an offset at certain zoom levels.
       // This is not necessary for parallel-path or fork-line layers as they require less precision.
       vec3 arrowPositionWorldSpace = mix(linePosition1, linePosition2, interpolationValue);
       float offsetCommonSpace = clamp(project_size_at_latitude(distanceBetweenLines, arrowPositionWorldSpace.y), project_pixel_size(minParallelOffset), project_pixel_size(maxParallelOffset));


### PR DESCRIPTION
Regression was introduced with deck.gl 8.6 and in particular alpha4 and this commit (https://github.com/visgl/deck.gl/pull/6117). In the release notes you can read that the way meters are projected in MapView has changed to take into account the Mercator projection (https://deck.gl/docs/upgrade-guide#meter-size-projection). They advise to
* use common units
* use `views: new MapView({legacyMeterSizes: true})` to recover the previous behavior.
The legacyMeterSizes boolean does indeed restore the previous behavior, but will be removed for version 9.0. 
It would be possible to use common units for distanceBetweenLines, which allows offset between superimposed lines. If you do this, you'll have to modify code elsewhere to ensure that labels are correctly positioned w.r.t arrows/lines (you can't really control projections with deck.gl's TextLayer/IconLayer). Using common units, we could set the distance between lines to a distance independent of latitude. This works well, but this is problematic for the TextLayer and IconLayer, which take latitude into account.
The solution adopted is to use another method than project_size() to switch from meters to common units, taking into account a more precise latitude. The arrow layer requires a high degree of precision when placing icons. The project_size() function in deck.gl does not return a high enough level of precision. I use the latitude of the icon's position to improve accuracy and solve the problem. 
I tested at different latitudes and it's OK. No impact on performance. 