### PR TITLE
Fix StudyDrawer : console warning

### DIFF
--- a/src/components/study-drawer.js
+++ b/src/components/study-drawer.js
@@ -62,6 +62,6 @@ export const StudyDrawer = ({ open, children, anchor }) => {
 
 StudyDrawer.propTypes = {
     open: PropTypes.bool,
-    children: PropTypes.object,
+    children: PropTypes.node,
     anchor: PropTypes.string,
 };


### PR DESCRIPTION
Warning: Failed prop type: Invalid prop `children` of type `array` supplied to `StudyDrawer`, expected `object`.