### PR TITLE
Add colors to map legend

### DIFF
--- a/src/components/network-map-tab.js
+++ b/src/components/network-map-tab.js
@@ -943,6 +943,7 @@ export const NetworkMapTab = ({
         return (
             <Box sx={styles.divNominalVoltageFilter}>
                 <NominalVoltageFilter
+                    lineFlowColorMode={lineFlowColorMode}
                     nominalVoltages={mapEquipments.getNominalVoltages()}
                     filteredNominalVoltages={filteredNominalVoltages}
                     onChange={setFilteredNominalVoltages}

--- a/src/components/network/nominal-voltage-filter.js
+++ b/src/components/network/nominal-voltage-filter.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import Checkbox from '@mui/material/Checkbox';
@@ -13,6 +13,8 @@ import ListItemText from '@mui/material/ListItemText';
 import Paper from '@mui/material/Paper';
 import { FormattedMessage } from 'react-intl';
 import Button from '@mui/material/Button';
+import { getNominalVoltageColor } from '../../utils/colors';
+import { LineFlowColorMode } from './line-layer';
 
 const styles = {
     nominalVoltageZone: {
@@ -43,6 +45,7 @@ const styles = {
 };
 
 const NominalVoltageFilter = ({
+    lineFlowColorMode,
     nominalVoltages,
     filteredNominalVoltages,
     onChange,
@@ -53,6 +56,21 @@ const NominalVoltageFilter = ({
             onChange(nominalVoltages);
         }
     }, [nominalVoltages, filteredNominalVoltages, onChange]);
+
+    const voltageColors = useMemo(() => {
+        if (
+            nominalVoltages &&
+            lineFlowColorMode &&
+            lineFlowColorMode !== LineFlowColorMode.NOMINAL_VOLTAGE
+        ) {
+            return null;
+        } else {
+            return nominalVoltages.reduce((mapValues, value, idx, arr) => {
+                mapValues[value] = `rgb(${getNominalVoltageColor(value)})`;
+                return mapValues;
+            }, {});
+        }
+    }, [lineFlowColorMode, nominalVoltages]);
 
     const handleToggle = (vnoms, isToggle) => () => {
         // filter on nominal voltage
@@ -117,7 +135,14 @@ const NominalVoltageFilter = ({
                                 }
                             />
                             <ListItemText
-                                sx={styles.nominalVoltageText}
+                                sx={
+                                    !voltageColors
+                                        ? styles.nominalVoltageText
+                                        : {
+                                              ...styles.nominalVoltageText,
+                                              color: voltageColors[value],
+                                          }
+                                }
                                 disableTypography
                                 primary={`${value} kV`}
                             />

--- a/src/components/voltage-level-choice.js
+++ b/src/components/voltage-level-choice.js
@@ -75,15 +75,6 @@ const VoltageLevelChoice = ({
                             let color = getNominalVoltageColor(
                                 voltageLevel.nominalVoltage
                             );
-                            let colorString =
-                                'rgb(' +
-                                color[0].toString() +
-                                ',' +
-                                color[1].toString() +
-                                ',' +
-                                color[2].toString() +
-                                ')';
-
                             return (
                                 <MenuItem
                                     sx={styles.nominalVoltageItem}
@@ -98,7 +89,7 @@ const VoltageLevelChoice = ({
                                             sx={styles.nominalVoltageButton}
                                             variant="contained"
                                             style={{
-                                                backgroundColor: colorString,
+                                                backgroundColor: `rgb(${color})`,
                                             }}
                                         >
                                             {voltageLevel.nominalVoltage}


### PR DESCRIPTION
Add colors to the main map legend, when map is in "Nominal tension" coloration mode, with each tension colored by same color use by lines on the map.