### PR TITLE
Fix the limit on number of voltage level for the SLD.

### DIFF
--- a/src/components/diagrams/diagram-pane.js
+++ b/src/components/diagrams/diagram-pane.js
@@ -267,7 +267,7 @@ const useDisplayView = (studyUuid, currentNode) => {
                         }
                         dispatch(
                             setNetworkAreaDiagramNbVoltageLevels(
-                                svg.metadata?.nbVoltageLevels
+                                svg.additionalMetadata?.nbVoltageLevels
                             )
                         );
                         return {


### PR DESCRIPTION
In the current version, we can increase the depth of the SLD to an infinite level because the limit on the number of voltage level is not taken into account.
The wrong metadata are used to get the additional metadata from the back.
@FranckLecuyer helped for this PR.