### PR TITLE
cleanup, remove unused transition and rename cssclass

### DIFF
--- a/src/components/study-pane.js
+++ b/src/components/study-pane.js
@@ -61,19 +61,13 @@ const styles = {
             },
         },
     },
-    mapCtrlBottomLeft: (theme) => ({
-        '& .mapboxgl-ctrl-bottom-left': {
-            transition: theme.transitions.create('left', {
-                easing: theme.transitions.easing.sharp,
-                duration: theme.transitions.duration.leavingScreen,
-            }),
-        },
+    mapBelowDiagrams: {
         position: 'absolute',
         top: 0,
         bottom: 0,
         left: 0,
         right: 0,
-    }),
+    },
     table: {
         display: 'flex',
         flexDirection: 'column',
@@ -198,7 +192,7 @@ const StudyPane = ({ studyUuid, currentNode, setErrorMessage, ...props }) => {
                                         : '100%',
                             }}
                         >
-                            <Box sx={styles.mapCtrlBottomLeft}>
+                            <Box sx={styles.mapBelowDiagrams}>
                                 {/* TODO do not display if study does not exists or do not fetch geoData if study does not exists */}
                                 <NetworkMapTab
                                     /* TODO do we move redux param to container */


### PR DESCRIPTION
This was used before be6b246ffa when we had drawers with transitions and the elements where manually positionned and transitioned between
  left: drawerToolbarWidth
  left: drawerExplorerWidth + drawerToolbarWidth
  left: drawerNetworkModificationTreeWidth + drawerToolbarWidth