### PR TITLE
map manual refresh, fix overlay zIndex not applied because position is not set

### DIFF
--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -47,6 +47,7 @@ const styles = {
         justifyContent: 'center',
         background: 'grey',
         opacity: '0.8',
+        position: 'relative',
         zIndex: 99,
         fontSize: 30,
     },


### PR DESCRIPTION
this gives it the same behavior as the initial "map loading" overlay