### PR TITLE
increase map maxZoom 12->14

### DIFF
--- a/src/components/network/network-map.js
+++ b/src/components/network/network-map.js
@@ -448,7 +448,7 @@ const NetworkMap = (props) => {
         longitude: props.initialPosition[0],
         latitude: props.initialPosition[1],
         zoom: props.initialZoom,
-        maxZoom: 12,
+        maxZoom: 14,
         pitch: 0,
         bearing: 0,
     };


### PR DESCRIPTION
The new version of deckgl/react-map-gl fixes the bug where you could zoom in more than the max zoom. So now we realize that users actually need a higher maxZoom.

We had chosen 12 because this is the limit that triggers the bug where the text label of active power on the map moves away from the arrow on the line so this will give this bug a little more visibility but it's not a blocker.