### PR TITLE
Fix DS Title in dialog translation warning

### DIFF
--- a/src/components/menus/dynamic-simulation/dynamic-simulation-event-menu-item.tsx
+++ b/src/components/menus/dynamic-simulation/dynamic-simulation-event-menu-item.tsx
@@ -51,11 +51,9 @@ const DynamicSimulationEventMenuItem = (
                 handleOpenDynamicSimulationEventDialog(
                     equipmentId,
                     equipmentType,
-                    intl.formatMessage({
-                        id: `${getEventType(equipmentType)}${
-                            EQUIPMENT_TYPE_LABEL_KEYS[equipmentType]
-                        }`,
-                    })
+                    `${getEventType(equipmentType)}${
+                        EQUIPMENT_TYPE_LABEL_KEYS[equipmentType]
+                    }`
                 )
             }
             disabled={disabled}


### PR DESCRIPTION
fix(): return only the titleId which is used un ModificationDialog later and translate