### PR TITLE
Move Typescript modules override

### DIFF
--- a/src/module-ag-grid-community.d.ts
+++ b/src/module-ag-grid-community.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { CrossValidationOptions } from './components/spreadsheet/utils/equipment-table-utils';
+
+declare module 'ag-grid-community' {
+    // used to add properties that are not supported by ColDef such as numeric, fractionDigits...
+    interface ColDef {
+        numeric?: boolean;
+        fractionDigits?: number;
+        crossValidation?: CrossValidationOptions;
+    }
+}

--- a/src/module-commons-ui.d.ts
+++ b/src/module-commons-ui.d.ts
@@ -53,7 +53,9 @@ declare module '@gridsuite/commons-ui' {
         previousValue?: string;
         allowNewValue?: boolean;
         onChangeCallback?: () => void;
-        getOptionLabel?: (rt: string | { id: string; label: string }) => string | null;
+        getOptionLabel?: (
+            rt: string | { id: string; label: string }
+        ) => string | null;
         formProps?: Omit<
             TextFieldProps,
             'value' | 'onChange' | 'inputRef' | 'inputProps' | 'InputProps'
@@ -185,7 +187,7 @@ declare module '@gridsuite/commons-ui' {
 
     export const DARK_THEME: string;
     export const LIGHT_THEME: string;
-  
+
     interface CheckboxInputProps {
         name: string;
         label?: string;

--- a/src/module-mui.d.ts
+++ b/src/module-mui.d.ts
@@ -5,13 +5,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Theme } from '@mui/material/styles';
-import { CrossValidationOptions } from './spreadsheet/utils/equipment-table-utils';
+import {
+    Theme as MuiTheme,
+    ThemeOptions as MuiThemeOptions,
+} from '@mui/material/styles/createTheme';
 
 // used to customize mui theme
 // https://mui.com/material-ui/customization/theming/#typescript
 declare module '@mui/material/styles' {
-    interface Theme {
+    export * from '@mui/material/styles';
+    interface ThemeExtension {
         aggrid: string;
         aggridValueChangeHighlightBackgroundColor: string;
         selectedRow: {
@@ -24,13 +27,10 @@ declare module '@mui/material/styles' {
             background: string;
         };
     }
-}
+    export interface Theme extends MuiTheme, Required<ThemeExtension> {}
 
-declare module 'ag-grid-community' {
-    // used to add properties that are not supported by ColDef such as numeric, fractionDigits...
-    interface ColDef {
-        numeric?: boolean;
-        fractionDigits?: number;
-        crossValidation?: CrossValidationOptions;
-    }
+    // allow configuration using `createTheme`
+    export interface ThemeOptions
+        extends MuiThemeOptions,
+            Partial<ThemeExtension> {}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
         "noEmit": true,
         "jsx": "react-jsx"
     },
-    "include": ["src","decs.d.ts"]
+    "include": ["src"]
 }


### PR DESCRIPTION
Mode TypeScript overrides to root of `/src`, and fix `Theme` override ([MUI doc](https://mui.com/material-ui/customization/theming/#typescript)).