### PR TITLE
Dynamic Simulation - Context menu does not disappear after opening dialog to edit an event

### DIFF
--- a/src/components/diagrams/singleLineDiagram/single-line-diagram-content.js
+++ b/src/components/diagrams/singleLineDiagram/single-line-diagram-content.js
@@ -305,9 +305,9 @@ function SingleLineDiagramContent(props) {
                     handleRunShortcircuitAnalysis={
                         handleRunShortcircuitAnalysis
                     }
-                    handleOpenDynamicSimulationEventDialog={makeOpenDynamicSimulationEventDialogHandler(
-                        closeBusMenu
-                    )}
+                    onOpenDynamicSimulationEventDialog={
+                        handleOpenDynamicSimulationEventDialog
+                    }
                     busId={busMenu.busId}
                     position={busMenu.position}
                     onClose={closeBusMenu}
@@ -358,9 +358,8 @@ function SingleLineDiagramContent(props) {
         ]
     );
 
-    const makeOpenDynamicSimulationEventDialogHandler = useCallback(
-        (closeMenu) => (equipmentId, equipmentType, dialogTitle) => {
-            closeMenu();
+    const handleOpenDynamicSimulationEventDialog = useCallback(
+        (equipmentId, equipmentType, dialogTitle) => {
             setDynamicSimulationEventDialogTitle(dialogTitle);
             setEquipmentToConfigDynamicSimulationEvent({
                 equipmentId,
@@ -388,9 +387,9 @@ function SingleLineDiagramContent(props) {
                     handleViewInSpreadsheet={handleViewInSpreadsheet}
                     handleDeleteEquipment={handleDeleteEquipment}
                     handleOpenModificationDialog={handleOpenModificationDialog}
-                    handleOpenDynamicSimulationEventDialog={makeOpenDynamicSimulationEventDialogHandler(
-                        closeEquipmentMenu
-                    )}
+                    onOpenDynamicSimulationEventDialog={
+                        handleOpenDynamicSimulationEventDialog
+                    }
                     currentNode={currentNode}
                     studyUuid={studyUuid}
                     modificationInProgress={modificationInProgress}
@@ -416,9 +415,9 @@ function SingleLineDiagramContent(props) {
                     handleViewInSpreadsheet={handleViewInSpreadsheet}
                     handleOpenModificationDialog={handleOpenModificationDialog}
                     handleDeleteEquipment={handleDeleteEquipment}
-                    handleOpenDynamicSimulationEventDialog={makeOpenDynamicSimulationEventDialogHandler(
-                        closeEquipmentMenu
-                    )}
+                    onOpenDynamicSimulationEventDialog={
+                        handleOpenDynamicSimulationEventDialog
+                    }
                 />
             )
         );

--- a/src/components/diagrams/singleLineDiagram/single-line-diagram-content.js
+++ b/src/components/diagrams/singleLineDiagram/single-line-diagram-content.js
@@ -305,9 +305,9 @@ function SingleLineDiagramContent(props) {
                     handleRunShortcircuitAnalysis={
                         handleRunShortcircuitAnalysis
                     }
-                    handleOpenDynamicSimulationEventDialog={
-                        handleOpenDynamicSimulationEventDialog
-                    }
+                    handleOpenDynamicSimulationEventDialog={handleOpenDynamicSimulationEventDialogFactory(
+                        closeBusMenu
+                    )}
                     busId={busMenu.busId}
                     position={busMenu.position}
                     onClose={closeBusMenu}
@@ -358,16 +358,16 @@ function SingleLineDiagramContent(props) {
         ]
     );
 
-    const handleOpenDynamicSimulationEventDialog = useCallback(
-        (equipmentId, equipmentType, dialogTitle) => {
-            closeEquipmentMenu();
+    const handleOpenDynamicSimulationEventDialogFactory = useCallback(
+        (closeMenu) => (equipmentId, equipmentType, dialogTitle) => {
+            closeMenu();
             setDynamicSimulationEventDialogTitle(dialogTitle);
             setEquipmentToConfigDynamicSimulationEvent({
                 equipmentId,
                 equipmentType,
             });
         },
-        [closeEquipmentMenu]
+        []
     );
 
     const handleCloseDynamicSimulationEventDialog = useCallback(() => {
@@ -388,9 +388,9 @@ function SingleLineDiagramContent(props) {
                     handleViewInSpreadsheet={handleViewInSpreadsheet}
                     handleDeleteEquipment={handleDeleteEquipment}
                     handleOpenModificationDialog={handleOpenModificationDialog}
-                    handleOpenDynamicSimulationEventDialog={
-                        handleOpenDynamicSimulationEventDialog
-                    }
+                    handleOpenDynamicSimulationEventDialog={handleOpenDynamicSimulationEventDialogFactory(
+                        closeEquipmentMenu
+                    )}
                     currentNode={currentNode}
                     studyUuid={studyUuid}
                     modificationInProgress={modificationInProgress}
@@ -416,9 +416,9 @@ function SingleLineDiagramContent(props) {
                     handleViewInSpreadsheet={handleViewInSpreadsheet}
                     handleOpenModificationDialog={handleOpenModificationDialog}
                     handleDeleteEquipment={handleDeleteEquipment}
-                    handleOpenDynamicSimulationEventDialog={
-                        handleOpenDynamicSimulationEventDialog
-                    }
+                    handleOpenDynamicSimulationEventDialog={handleOpenDynamicSimulationEventDialogFactory(
+                        closeEquipmentMenu
+                    )}
                 />
             )
         );

--- a/src/components/diagrams/singleLineDiagram/single-line-diagram-content.js
+++ b/src/components/diagrams/singleLineDiagram/single-line-diagram-content.js
@@ -305,7 +305,7 @@ function SingleLineDiagramContent(props) {
                     handleRunShortcircuitAnalysis={
                         handleRunShortcircuitAnalysis
                     }
-                    handleOpenDynamicSimulationEventDialog={handleOpenDynamicSimulationEventDialogFactory(
+                    handleOpenDynamicSimulationEventDialog={makeOpenDynamicSimulationEventDialogHandler(
                         closeBusMenu
                     )}
                     busId={busMenu.busId}
@@ -358,7 +358,7 @@ function SingleLineDiagramContent(props) {
         ]
     );
 
-    const handleOpenDynamicSimulationEventDialogFactory = useCallback(
+    const makeOpenDynamicSimulationEventDialogHandler = useCallback(
         (closeMenu) => (equipmentId, equipmentType, dialogTitle) => {
             closeMenu();
             setDynamicSimulationEventDialogTitle(dialogTitle);
@@ -388,7 +388,7 @@ function SingleLineDiagramContent(props) {
                     handleViewInSpreadsheet={handleViewInSpreadsheet}
                     handleDeleteEquipment={handleDeleteEquipment}
                     handleOpenModificationDialog={handleOpenModificationDialog}
-                    handleOpenDynamicSimulationEventDialog={handleOpenDynamicSimulationEventDialogFactory(
+                    handleOpenDynamicSimulationEventDialog={makeOpenDynamicSimulationEventDialogHandler(
                         closeEquipmentMenu
                     )}
                     currentNode={currentNode}
@@ -416,7 +416,7 @@ function SingleLineDiagramContent(props) {
                     handleViewInSpreadsheet={handleViewInSpreadsheet}
                     handleOpenModificationDialog={handleOpenModificationDialog}
                     handleDeleteEquipment={handleDeleteEquipment}
-                    handleOpenDynamicSimulationEventDialog={handleOpenDynamicSimulationEventDialogFactory(
+                    handleOpenDynamicSimulationEventDialog={makeOpenDynamicSimulationEventDialogHandler(
                         closeEquipmentMenu
                     )}
                 />

--- a/src/components/menus/branch-menu.js
+++ b/src/components/menus/branch-menu.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import Menu from '@mui/material/Menu';
 
 import ListItemText from '@mui/material/ListItemText';
@@ -63,7 +63,7 @@ const withBranchMenu =
         handleViewInSpreadsheet,
         handleDeleteEquipment,
         handleOpenModificationDialog,
-        handleOpenDynamicSimulationEventDialog,
+        onOpenDynamicSimulationEventDialog,
         currentNode,
         studyUuid,
         modificationInProgress,
@@ -158,6 +158,18 @@ const withBranchMenu =
             );
         }
 
+        const handleOpenDynamicSimulationEventDialog = useCallback(
+            (equipmentId, equipmentType, dialogTitle) => {
+                handleClose();
+                onOpenDynamicSimulationEventDialog(
+                    equipmentId,
+                    equipmentType,
+                    dialogTitle
+                );
+            },
+            [handleClose, onOpenDynamicSimulationEventDialog]
+        );
+
         return (
             <Menu
                 anchorReference="anchorPosition"
@@ -229,7 +241,7 @@ const withBranchMenu =
                     <DynamicSimulationEventMenuItem
                         equipmentId={equipment.id}
                         equipmentType={equipmentType}
-                        handleOpenDynamicSimulationEventDialog={
+                        onOpenDynamicSimulationEventDialog={
                             handleOpenDynamicSimulationEventDialog
                         }
                         disabled={
@@ -396,7 +408,7 @@ withBranchMenu.propTypes = {
     handleViewInSpreadsheet: PropTypes.func.isRequired,
     handleDeleteEquipment: PropTypes.func.isRequired,
     handleOpenModificationDialog: PropTypes.func.isRequired,
-    handleOpenDynamicSimulationEventDialog: PropTypes.func.isRequired,
+    onOpenDynamicSimulationEventDialog: PropTypes.func.isRequired,
     currentNode: PropTypes.object,
     studyUuid: PropTypes.string.isRequired,
     modificationInProgress: PropTypes.func,

--- a/src/components/menus/bus-menu.tsx
+++ b/src/components/menus/bus-menu.tsx
@@ -28,7 +28,7 @@ import { CustomMenuItem } from '../utils/custom-nested-menu';
 interface BusMenuProps {
     busId: string;
     handleRunShortcircuitAnalysis: (busId: string) => void;
-    handleOpenDynamicSimulationEventDialog: (
+    onOpenDynamicSimulationEventDialog: (
         equipmentId: string,
         equipmentType: string,
         dialogTitle: string
@@ -54,7 +54,7 @@ const styles = {
 export const BusMenu: FunctionComponent<BusMenuProps> = ({
     busId,
     handleRunShortcircuitAnalysis,
-    handleOpenDynamicSimulationEventDialog,
+    onOpenDynamicSimulationEventDialog,
     position,
     onClose,
 }) => {
@@ -86,6 +86,18 @@ export const BusMenu: FunctionComponent<BusMenuProps> = ({
         onClose();
         handleRunShortcircuitAnalysis(busId);
     }, [busId, onClose, handleRunShortcircuitAnalysis]);
+
+    const handleOpenDynamicSimulationEventDialog = useCallback(
+        (equipmentId: string, equipmentType: string, dialogTitle: string) => {
+            onClose();
+            onOpenDynamicSimulationEventDialog(
+                equipmentId,
+                equipmentType,
+                dialogTitle
+            );
+        },
+        [onClose, onOpenDynamicSimulationEventDialog]
+    );
 
     return (
         <Menu
@@ -124,7 +136,7 @@ export const BusMenu: FunctionComponent<BusMenuProps> = ({
                 <DynamicSimulationEventMenuItem
                     equipmentId={busId}
                     equipmentType={EQUIPMENT_TYPES.BUS}
-                    handleOpenDynamicSimulationEventDialog={
+                    onOpenDynamicSimulationEventDialog={
                         handleOpenDynamicSimulationEventDialog
                     }
                     disabled={!isNodeEditable}

--- a/src/components/menus/dynamic-simulation/dynamic-simulation-event-menu-item.tsx
+++ b/src/components/menus/dynamic-simulation/dynamic-simulation-event-menu-item.tsx
@@ -26,7 +26,7 @@ const styles = {
 interface DynamicSimulationEventMenuItemProps {
     equipmentId: string;
     equipmentType: string;
-    handleOpenDynamicSimulationEventDialog: (
+    onOpenDynamicSimulationEventDialog: (
         equipmentId: string,
         equipmentType: string,
         dialogTitle: string
@@ -41,14 +41,14 @@ const DynamicSimulationEventMenuItem = (
     const {
         equipmentId,
         equipmentType,
-        handleOpenDynamicSimulationEventDialog,
+        onOpenDynamicSimulationEventDialog,
         disabled,
     } = props;
     return (
         <CustomMenuItem
             sx={styles.menuItem}
             onClick={() =>
-                handleOpenDynamicSimulationEventDialog(
+                onOpenDynamicSimulationEventDialog(
                     equipmentId,
                     equipmentType,
                     `${getEventType(equipmentType)}${

--- a/src/components/menus/equipment-menu.js
+++ b/src/components/menus/equipment-menu.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import Menu from '@mui/material/Menu';
 import { useParameterState } from '../dialogs/parameters/parameters';
 import { PARAM_DEVELOPER_MODE } from '../../utils/config-params';
@@ -32,7 +32,7 @@ const withEquipmentMenu =
         handleViewInSpreadsheet,
         handleDeleteEquipment,
         handleOpenModificationDialog,
-        handleOpenDynamicSimulationEventDialog,
+        onOpenDynamicSimulationEventDialog,
     }) => {
         const [enableDeveloperMode] = useParameterState(PARAM_DEVELOPER_MODE);
 
@@ -45,6 +45,18 @@ const withEquipmentMenu =
                 !isNodeReadOnly(currentNode) &&
                 !isAnyNodeBuilding,
             [currentNode, isAnyNodeBuilding]
+        );
+
+        const handleOpenDynamicSimulationEventDialog = useCallback(
+            (equipmentId, equipmentType, dialogTitle) => {
+                handleClose();
+                onOpenDynamicSimulationEventDialog(
+                    equipmentId,
+                    equipmentType,
+                    dialogTitle
+                );
+            },
+            [handleClose, onOpenDynamicSimulationEventDialog]
         );
 
         return (
@@ -70,7 +82,7 @@ const withEquipmentMenu =
                     <DynamicSimulationEventMenuItem
                         equipmentId={equipment.id}
                         equipmentType={equipmentType}
-                        handleOpenDynamicSimulationEventDialog={
+                        onOpenDynamicSimulationEventDialog={
                             handleOpenDynamicSimulationEventDialog
                         }
                         disabled={!isNodeEditable}


### PR DESCRIPTION
**Produce bug:**
 
1. Open SLD diagram 
2. Click on a BUS to show the menu, then click on 'Node fault on bus (Dynamic simulation)'
3. The dialogue opened but the menu is not closed.

**Bug demo:**

![image](https://github.com/gridsuite/gridstudy-app/assets/117309322/9841e11c-bb7f-49ab-8754-f5773301c4fe)

**Solution:** invoke handle close menu function inside each specific menu