### PR TITLE
Fix: empty snackError

### DIFF
--- a/src/components/network/map-equipments.js
+++ b/src/components/network/map-equipments.js
@@ -178,11 +178,10 @@ export default class MapEquipments {
         updatedLines.catch((error) => {
             console.error(error.message);
             if (this.errHandler) {
-                this.errHandler(
-                    this.intlRef.current.formatMessage({
-                        id: 'MapEquipmentsLoadError',
-                    })
-                );
+                this.errHandler({
+                    messageTxt: error.message,
+                    headerId: 'MapEquipmentsLoadError',
+                });
             }
         });
         updatedHvdcLines.catch((error) => {


### PR DESCRIPTION
fix(mapEquipments): in reloadImpactedSubstationsEquipments, if  updatedLines Promise throw an error, it called a snackError with empty message. Use SnackInputs type params like others usage