### PR TITLE
Fix Tooltip disabled component warning

### DIFF
--- a/src/components/dialogs/parameters/sensi/sensitivity-table.tsx
+++ b/src/components/dialogs/parameters/sensi/sensitivity-table.tsx
@@ -137,12 +137,14 @@ const SensitivityTable: FunctionComponent<SensitivityTableProps> = ({
                                 id: 'AddRows',
                             })}
                         >
-                            <IconButton
-                                disabled={disableAdd}
-                                onClick={handleAddRowsButton}
-                            >
-                                <AddCircleIcon />
-                            </IconButton>
+                            <span>
+                                <IconButton
+                                    disabled={disableAdd}
+                                    onClick={handleAddRowsButton}
+                                >
+                                    <AddCircleIcon />
+                                </IconButton>
+                            </span>
                         </Tooltip>
                     </TableCell>
                 </TableHead>

--- a/src/components/results/dynamicsimulation/common/tooltip-icon-button.js
+++ b/src/components/results/dynamicsimulation/common/tooltip-icon-button.js
@@ -17,13 +17,15 @@ const TooltipIconButton = ({
 }) => {
     return (
         <Tooltip title={toolTip}>
-            <IconButton
-                size={'medium'}
-                onClick={onClick}
-                children={children}
-                disabled={disabled}
-                {...props}
-            />
+            <span>
+                <IconButton
+                    size={'medium'}
+                    onClick={onClick}
+                    children={children}
+                    disabled={disabled}
+                    {...props}
+                />
+            </span>
         </Tooltip>
     );
 };

--- a/src/components/utils/rhf-inputs/directory-items-input.tsx
+++ b/src/components/utils/rhf-inputs/directory-items-input.tsx
@@ -154,16 +154,18 @@ const DirectoryItemsInput: FunctionComponent<DirectoryItemsInputProps> = ({
                         <Tooltip
                             title={intl.formatMessage({ id: 'chooseElement' })}
                         >
-                            <IconButton
-                                sx={styles.addDirectoryElements}
-                                size={'small'}
-                                disabled={disable}
-                                onClick={() =>
-                                    setDirectoryItemSelectorOpen(true)
-                                }
-                            >
-                                <FolderIcon />
-                            </IconButton>
+                            <span>
+                                <IconButton
+                                    sx={styles.addDirectoryElements}
+                                    size={'small'}
+                                    disabled={disable}
+                                    onClick={() =>
+                                        setDirectoryItemSelectorOpen(true)
+                                    }
+                                >
+                                    <FolderIcon />
+                                </IconButton>
+                            </span>
                         </Tooltip>
                     </Grid>
                 </Grid>


### PR DESCRIPTION
```
MUI: You are providing a disabled `button` child to the Tooltip component.
A disabled element does not fire events.
Tooltip needs to listen to the child element's events to display the title.

Add a simple wrapper element, such as a `span`. 
```