### PR TITLE
Remove EXTEND_ESLINT from environment configuration.

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,2 @@
 VITE_API_GATEWAY=api/gateway
 VITE_WS_GATEWAY=ws/gateway
-EXTEND_ESLINT=true


### PR DESCRIPTION
Was used by CRA.