### PR TITLE
Refactor isNodeRestorationAllowed function to remove unnecessary condition

### DIFF
--- a/src/components/graph/menus/create-node-menu.jsx
+++ b/src/components/graph/menus/create-node-menu.jsx
@@ -190,7 +190,7 @@ const CreateNodeMenu = ({
     }
 
     function isNodeRestorationAllowed() {
-        return !isAnyNodeBuilding && !mapDataLoading && !disableRestoreNodes;
+        return !isAnyNodeBuilding && !disableRestoreNodes;
     }
 
     function isNodeAlreadySelectedForCut() {


### PR DESCRIPTION
This pull request refactors the isNodeRestorationAllowed function in the create-node-menu.jsx file to remove an unnecessary condition. 