### PR TITLE
ESLint: solve symlink resolution with `npm link`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,9 @@ export default defineConfig({
         reactVirtualized(),
         tsconfigPaths(), // to resolve absolute path via tsconfig cf https://stackoverflow.com/a/68250175/5092999
     ],
+    resolve: {
+        preserveSymlinks: true, //else eslint don't detect "npm link" packages
+    },
     base: './',
     server: serverSettings, // for npm run start
     preview: serverSettings, // for npm run serve (use local build)


### PR DESCRIPTION
Fix the path detection problem with `ignorePatterns` when using [`npm link`](https://vitejs.dev/config/shared-options#resolve-preservesymlinks) (local dependency not in `node_modules`).

Discussion here: https://github.com/gridsuite/gridstudy-app/pull/1995#discussion_r1525014216