### PR TITLE
Add depcheck in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
               run: |
                   npm install
                   npm run lint
+                  npm run depcheck
                   npm run test
                   npm run build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
                 "@vitejs/plugin-react": "^4.2.1",
                 "babel-eslint": "^10.1.0",
                 "babel-preset-vite": "^1.1.3",
+                "depcheck": "^1.4.7",
                 "eslint": "^7.9.0",
                 "eslint-config-prettier": "^8.0.0",
                 "eslint-config-react-app": "^6.0.0",
@@ -5451,6 +5452,12 @@
                 "@types/geojson": "*"
             }
         },
+        "node_modules/@types/minimatch": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+            "dev": true
+        },
         "node_modules/@types/node": {
             "version": "20.2.3",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.3.tgz",
@@ -5807,6 +5814,62 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.4.21",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.21.tgz",
+            "integrity": "sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.23.9",
+                "@vue/shared": "3.4.21",
+                "entities": "^4.5.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.4.21",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz",
+            "integrity": "sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.4.21",
+                "@vue/shared": "3.4.21"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.4.21",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.21.tgz",
+            "integrity": "sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.23.9",
+                "@vue/compiler-core": "3.4.21",
+                "@vue/compiler-dom": "3.4.21",
+                "@vue/compiler-ssr": "3.4.21",
+                "@vue/shared": "3.4.21",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.7",
+                "postcss": "^8.4.35",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.4.21",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.21.tgz",
+            "integrity": "sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.4.21",
+                "@vue/shared": "3.4.21"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.4.21",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.21.tgz",
+            "integrity": "sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g==",
+            "dev": true
+        },
         "node_modules/abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -6027,6 +6090,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/array-differ": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/array-includes": {
             "version": "3.1.7",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
@@ -6162,6 +6234,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/arrify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/asap": {
@@ -6753,6 +6834,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/callsite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+            "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/callsites": {
@@ -7545,6 +7635,133 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/depcheck": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-1.4.7.tgz",
+            "integrity": "sha512-1lklS/bV5chOxwNKA/2XUUk/hPORp8zihZsXflr8x0kLwmcZ9Y9BsS6Hs3ssvA+2wUVbG0U2Ciqvm1SokNjPkA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.23.0",
+                "@babel/traverse": "^7.23.2",
+                "@vue/compiler-sfc": "^3.3.4",
+                "callsite": "^1.0.0",
+                "camelcase": "^6.3.0",
+                "cosmiconfig": "^7.1.0",
+                "debug": "^4.3.4",
+                "deps-regex": "^0.2.0",
+                "findup-sync": "^5.0.0",
+                "ignore": "^5.2.4",
+                "is-core-module": "^2.12.0",
+                "js-yaml": "^3.14.1",
+                "json5": "^2.2.3",
+                "lodash": "^4.17.21",
+                "minimatch": "^7.4.6",
+                "multimatch": "^5.0.0",
+                "please-upgrade-node": "^3.2.0",
+                "readdirp": "^3.6.0",
+                "require-package-name": "^2.0.1",
+                "resolve": "^1.22.3",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.5.4",
+                "yargs": "^16.2.0"
+            },
+            "bin": {
+                "depcheck": "bin/depcheck.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/depcheck/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/depcheck/node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/depcheck/node_modules/js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/depcheck/node_modules/minimatch": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+            "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/depcheck/node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/depcheck/node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/depcheck/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/deps-regex": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.2.0.tgz",
+            "integrity": "sha512-PwuBojGMQAYbWkMXOY9Pd/NWCDNHVH12pnS7WHqZkTSeMESe4hwnKKRp0yR87g37113x4JPbo/oIvXY+s/f56Q==",
+            "dev": true
+        },
         "node_modules/dequal": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -7552,6 +7769,15 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/detect-file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/detect-newline": {
@@ -8548,6 +8774,12 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -8592,6 +8824,18 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+            "dev": true,
+            "dependencies": {
+                "homedir-polyfill": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/expect": {
@@ -8769,6 +9013,21 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
             "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+        },
+        "node_modules/findup-sync": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
+            "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
+            "dev": true,
+            "dependencies": {
+                "detect-file": "^1.0.0",
+                "is-glob": "^4.0.3",
+                "micromatch": "^4.0.4",
+                "resolve-dir": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
         },
         "node_modules/flat-cache": {
             "version": "3.2.0",
@@ -9042,6 +9301,36 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/global-modules": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+            "dev": true,
+            "dependencies": {
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/global-modules/node_modules/global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+            "dev": true,
+            "dependencies": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/global-prefix": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
@@ -9255,6 +9544,18 @@
             "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
             "dependencies": {
                 "react-is": "^16.7.0"
+            }
+        },
+        "node_modules/homedir-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+            "dev": true,
+            "dependencies": {
+                "parse-passwd": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/html-encoding-sniffer": {
@@ -9848,6 +10149,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/isarray": {
@@ -11939,6 +12249,18 @@
             "resolved": "https://registry.npmjs.org/lucene-escape-query/-/lucene-escape-query-1.0.1.tgz",
             "integrity": "sha512-iuB/RqAZjHI9YWm3zyM8qQkPxCi5nA3zcYZn71UM/W/+wh26fWpfxkLKZSgogoAvBjhN/4NhR+hxk2gScc81ow=="
         },
+        "node_modules/magic-string": {
+            "version": "0.30.8",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+            "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.15"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/make-dir": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -12198,6 +12520,25 @@
                 "@types/react": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/multimatch": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
+            "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
+            "dev": true,
+            "dependencies": {
+                "@types/minimatch": "^3.0.3",
+                "array-differ": "^3.0.0",
+                "array-union": "^2.1.0",
+                "arrify": "^2.0.1",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/murmurhash-js": {
@@ -12551,6 +12892,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/parse5": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
@@ -12731,15 +13081,24 @@
                 "node": ">=8"
             }
         },
+        "node_modules/please-upgrade-node": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+            "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+            "dev": true,
+            "dependencies": {
+                "semver-compare": "^1.0.0"
+            }
+        },
         "node_modules/plotly.js-basic-dist-min": {
             "version": "2.21.0",
             "resolved": "https://registry.npmjs.org/plotly.js-basic-dist-min/-/plotly.js-basic-dist-min-2.21.0.tgz",
             "integrity": "sha512-+Bwe1aOEZh14OYi37SSWtLAI3umuJO61HVLyMZcT748vkjhTX0tqzAF5y1v0q/AZd7rHMMzO+VinqIDqvqpxcQ=="
         },
         "node_modules/postcss": {
-            "version": "8.4.33",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
-            "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+            "version": "8.4.38",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
             "dev": true,
             "funding": [
                 {
@@ -12758,7 +13117,7 @@
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "source-map-js": "^1.2.0"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -13417,6 +13776,18 @@
             "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
             "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
         },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
         "node_modules/reconnecting-websocket": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
@@ -13582,6 +13953,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/require-package-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+            "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
+            "dev": true
+        },
         "node_modules/requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -13628,6 +14005,19 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+            "dev": true,
+            "dependencies": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/resolve-from": {
@@ -13816,6 +14206,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/semver-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+            "dev": true
         },
         "node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
@@ -14048,9 +14444,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -15083,12 +15479,6 @@
                 "node": ">= 8.0.0"
             }
         },
-        "node_modules/vite-plugin-eslint/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true
-        },
         "node_modules/vite-plugin-svgr": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-4.2.0.tgz",
@@ -15363,12 +15753,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/vite-plugin-svgr/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true
         },
         "node_modules/vite-tsconfig-paths": {
             "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "start": "vite",
         "start:open": "vite --open",
         "build": "tsc && vite build",
+        "depcheck": "depcheck",
         "serve": "vite preview",
         "test": "jest",
         "lint": "eslint . --ext js,mjs,jsx,ts,mts,tsx --max-warnings 0"
@@ -76,6 +77,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "babel-eslint": "^10.1.0",
         "babel-preset-vite": "^1.1.3",
+        "depcheck": "^1.4.7",
         "eslint": "^7.9.0",
         "eslint-config-prettier": "^8.0.0",
         "eslint-config-react-app": "^6.0.0",


### PR DESCRIPTION
We can probably use --ignore if necessary: https://github.com/depcheck/depcheck?tab=readme-ov-file#usage for example `"depcheck": "depcheck --ignores=\"mjolnir.js,babel-*\"",`
Output of the check: 
```
Unused dependencies
* @svgdotjs/svg.js
* @svgdotjs/svg.panzoom.js
* @types/react-beautiful-dnd
* lucene-escape-query
* mjolnir.js
* qs
* react-json-view
* react-window
Unused devDependencies
* @babel/helper-builder-react-jsx
* identity-obj-proxy
* jest-environment-jsdom
* jest-svg-transformer
* ts-node
Missing dependencies
* prop-types: ./src/utils/dialogs.jsx
* hooks: ./src/services/study/loadflow.js
* components: ./src/redux/reducer.js
* services: ./src/hooks/use-update-equipments.ts
* utils: ./src/components/parameters-tabs.tsx
* @mui/system: ./src/components/report-viewer-tab.jsx
* file-saver: ./src/components/results/sensitivity-analysis/non-evacuated-energy/non-evacuated-energy-result.tsx
* @mui/base: ./src/components/dialogs/parameters/widget/ParameterLine.tsx
* papaparse: ./src/components/dialogs/network-modifications/two-windings-transformer/tap-changer-pane/tap-changer-steps.jsx
```