### PR TITLE
Merge fetch of VL and NV by changing data type

### DIFF
--- a/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/equipment-filter.jsx
+++ b/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/equipment-filter.jsx
@@ -25,7 +25,7 @@ import {
     fetchAllNominalVoltages,
 } from '../../../../../../services/study/network-map';
 import { evaluateJsonFilter } from '../../../../../../services/study/filter';
-import { fetchVoltageLevelsListInfos } from '../../../../../../services/study/network';
+import { fetchVoltageLevelsMapInfos } from '../../../../../../services/study/network';
 import CheckboxAutocomplete from '../../../../../utils/checkbox-autocomplete';
 import { useLocalizedCountries } from '../../../../../utils/localized-countries-hook';
 import {
@@ -96,27 +96,22 @@ const EquipmentFilter = forwardRef(
         // fetching options in different criterias
         useEffect(() => {
             // Load voltage level IDs
-            fetchVoltageLevelsListInfos(studyUuid, currentNode.id)
+            fetchVoltageLevelsMapInfos(studyUuid, currentNode.id)
                 .then((voltageLevels) => {
                     const vlMap = new Map();
-                    voltageLevels.forEach((vl) => vlMap.set(vl.id, vl.name));
+                    const nvSet = new Set();
+                    voltageLevels.forEach((vl) => {
+                        vlMap.set(vl.id, vl.name);
+                        nvSet.add(vl.nominalV);
+                    });
                     setVoltageLevelsMap(vlMap);
+                    setNominalVoltages([...nvSet.values()].sort());
                     setVoltageLevelIds([...vlMap.keys()]);
                 })
                 .catch((error) => {
                     snackError({
                         messageTxt: error.message,
                         headerId: 'FetchVoltageLevelsError',
-                    });
-                });
-
-            // Load nominal voltages
-            fetchAllNominalVoltages(studyUuid, currentNode.id)
-                .then((nominalVoltages) => setNominalVoltages(nominalVoltages))
-                .catch((error) => {
-                    snackError({
-                        messageTxt: error.message,
-                        headerId: 'FetchNominalVoltagesError',
                     });
                 });
 

--- a/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/equipment-filter.jsx
+++ b/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/equipment-filter.jsx
@@ -102,7 +102,9 @@ const EquipmentFilter = forwardRef(
                         nvSet.add(vl.nominalV);
                     });
                     setVoltageLevelsMap(vlMap);
-                    setNominalVoltages([...nvSet.values()].sort());
+                    setNominalVoltages(
+                        [...nvSet.values()].sort((nv1, nv2) => nv1 - nv2)
+                    );
                     setVoltageLevelIds([...vlMap.keys()]);
                 })
                 .catch((error) => {

--- a/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/equipment-filter.jsx
+++ b/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/equipment-filter.jsx
@@ -20,10 +20,7 @@ import { useSelector } from 'react-redux';
 import { useSnackMessage } from '@gridsuite/commons-ui';
 import { Box } from '@mui/system';
 import { CustomAGGrid } from '../../../../../custom-aggrid/custom-aggrid';
-import {
-    fetchAllCountries,
-    fetchAllNominalVoltages,
-} from '../../../../../../services/study/network-map';
+import { fetchAllCountries } from '../../../../../../services/study/network-map';
 import { evaluateJsonFilter } from '../../../../../../services/study/filter';
 import { fetchVoltageLevelsMapInfos } from '../../../../../../services/study/network';
 import CheckboxAutocomplete from '../../../../../utils/checkbox-autocomplete';

--- a/src/services/study/network.js
+++ b/src/services/study/network.js
@@ -319,6 +319,21 @@ export function fetchVoltageLevelsListInfos(
     );
 }
 
+export function fetchVoltageLevelsMapInfos(
+    studyUuid,
+    currentNodeUuid,
+    substationsIds
+) {
+    return fetchNetworkElementsInfos(
+        studyUuid,
+        currentNodeUuid,
+        substationsIds,
+        EQUIPMENT_TYPES.VOLTAGE_LEVEL,
+        EQUIPMENT_INFOS_TYPES.MAP.type,
+        true
+    );
+}
+
 export function fetchTwoWindingsTransformers(
     studyUuid,
     currentNodeUuid,


### PR DESCRIPTION
Change fetchVoltageLevelsListInfos to fetchVoltageLevelsMapInfos for better data handling and efficiency. Update equipment-filter.jsx to implement new function and handle nominal voltages accordingly.