### PR TITLE
Fix lf param reset (param+provider) race condition when user has a profile

### DIFF
--- a/src/components/dialogs/parameters/load-flow-parameters.jsx
+++ b/src/components/dialogs/parameters/load-flow-parameters.jsx
@@ -522,8 +522,7 @@ export const LoadFlowParameters = ({ parametersBackend }) => {
 
     const resetLfParametersAndLfProvider = useCallback(() => {
         setSpecificCurrentParams({});
-        resetParameters();
-        resetProvider();
+        resetParameters().then(resetProvider);
     }, [resetParameters, resetProvider]);
 
     const resetLfParameters = useCallback(() => {

--- a/src/components/dialogs/parameters/parameters.jsx
+++ b/src/components/dialogs/parameters/parameters.jsx
@@ -363,7 +363,7 @@ export const useParametersBackend = (
 
     const resetParameters = useCallback(
         (callBack) => {
-            backendUpdateParameters(studyUuid, null)
+            return backendUpdateParameters(studyUuid, null)
                 .then((response) => {
                     if (response.status === 204) {
                         snackWarning({


### PR DESCRIPTION
When the user has a profile, to reset the parameters the study server deletes and creates new parameters with a new UUID. But if you call updateProvider in parallel, the study server has time to read the deleted parameter ID from the study and tries to update the parameters after they were deleted.

gridstudy-study-server-1                   | org.springframework.web.client.HttpServerErrorException$InternalServerError: 500 : "{"timestamp":"2024-05-07T12:05:40.080+00:00","status":500,"error":"Internal Server Error","message":"No value present","path":"/v1/parameters/c73808c2-b240-4115-bf1b-91afe66efce5/provider"}"

gridstudy-loadflow-server-1                | java.util.NoSuchElementException: No value present
gridstudy-loadflow-server-1                | 	at java.base/java.util.Optional.orElseThrow(Unknown Source) ~[na:na]
gridstudy-loadflow-server-1                | 	at org.gridsuite.loadflow.server.service.LoadFlowParametersService.updateProvider(LoadFlowParametersService.java:101) ~[classes/:na]