### PR TITLE
Fix empty couplingDevices when VL creation by copy

### DIFF
--- a/src/components/dialogs/network-modifications/voltage-level/creation/voltage-level-creation-dialog.jsx
+++ b/src/components/dialogs/network-modifications/voltage-level/creation/voltage-level-creation-dialog.jsx
@@ -186,7 +186,7 @@ const VoltageLevelCreationDialog = ({
                         return intl.formatMessage({ id: switchKind });
                     })
                     .join(' / '),
-                [COUPLING_OMNIBUS]: voltageLevel.couplingDevices,
+                [COUPLING_OMNIBUS]: voltageLevel.couplingDevices ?? [],
                 [SWITCH_KINDS]:
                     voltageLevel.switchKinds != null
                         ? voltageLevel.switchKinds?.map((switchKind) => ({


### PR DESCRIPTION
Fixed a bug in voltage-level-creation-dialog.jsx where COUPLING_OMNIBUS was not being properly handled, now defaults to an empty array.

probably introduced by #2072 