### PR TITLE
Add filter name validation

### DIFF
--- a/src/components/dialogs/commons/unique-name-input.tsx
+++ b/src/components/dialogs/commons/unique-name-input.tsx
@@ -28,6 +28,7 @@ interface UniqueNameInputProps {
     autoFocus?: boolean;
     onManualChangeCallback?: () => void;
     activeDirectory: UUID | null;
+    triggerValidation?: boolean;
     formProps?: Omit<
         TextFieldProps,
         | 'value'
@@ -100,7 +101,7 @@ export const UniqueNameInput: FunctionComponent<UniqueNameInputProps> = (
     // We have to use an useEffect because the name can change from outside of this component (when we upload a case file for instance)
     useEffect(() => {
         // if the name is unchanged, we don't do custom validation
-        if (!isDirty) {
+        if (!isDirty && !props.triggerValidation) {
             clearErrors(props.name);
             return;
         }
@@ -126,6 +127,7 @@ export const UniqueNameInput: FunctionComponent<UniqueNameInputProps> = (
         props.name,
         value,
         isDirty,
+        props.triggerValidation,
     ]);
 
     // Handle on user's change

--- a/src/components/network/filter-creation-panel.tsx
+++ b/src/components/network/filter-creation-panel.tsx
@@ -171,8 +171,9 @@ const FilterCreationPanel: React.FC<FilterCreationPanelProps> = ({
                         <UniqueNameInput
                             name={NAME}
                             label={'Name'}
-                            elementType={ElementType.DIRECTORY}
+                            elementType={ElementType.FILTER}
                             activeDirectory={defaultFolder?.id as UUID}
+                            triggerValidation={!savingState}
                             autoFocus
                             formProps={{ variant: 'standard' }}
                         />


### PR DESCRIPTION
This pull request adds validation for the filter name input field. Previously, the validation was not triggered when the name was unchanged. With this change, the validation will be triggered even if the name is unchanged. This ensures that the input field is properly validated.

