### PR TITLE
[Dynamic Simulation] Can not trip the line from DSL

### DIFF
--- a/src/components/dialogs/dynamicsimulation/event/model/event.model.ts
+++ b/src/components/dialogs/dynamicsimulation/event/model/event.model.ts
@@ -40,6 +40,7 @@ export const DISCONNECT_EVENT_DEFINITION: EventDefinition = {
         acceptOnly: (equipmentType: string) => {
             return BRANCH_EQUIPMENT_TYPES.includes(equipmentType);
         },
+        default: null,
     },
 };
 


### PR DESCRIPTION
Due to the modif : https://github.com/gridsuite/commons-ui/pull/432/files#diff-b891b5128b3aa4efdf36efac0cbadfadfa2cd2a755849485ebe3959a49914965L97
=> can not trip the line from DSL

Solution: set default value as null which is an accepted value for select input