### PR TITLE
Fix null param in getQueryParamsList

### DIFF
--- a/src/services/study/network-map.js
+++ b/src/services/study/network-map.js
@@ -86,13 +86,16 @@ export function fetchVoltageLevelEquipments(
 export function fetchEquipmentsIds(
     studyUuid,
     currentNodeUuid,
-    substationsIds,
+    substationsIds = undefined,
     equipmentType,
     inUpstreamBuiltParentNode,
     nominalVoltages = undefined
 ) {
+    const substationsCount = substationsIds ? substationsIds.length : 0;
+    const nominalVoltagesStr = nominalVoltages ? `[${nominalVoltages}]` : '[]';
+
     console.info(
-        `Fetching equipments ids '${equipmentType}' of study '${studyUuid}' and node '${currentNodeUuid}' for ${substationsIds?.length} substations ids and [${nominalVoltages}] nominal voltages.`
+        `Fetching equipments ids '${equipmentType}' of study '${studyUuid}' and node '${currentNodeUuid}' for ${substationsCount} substations ids and ${nominalVoltagesStr} nominal voltages.`
     );
     let urlSearchParams = new URLSearchParams();
 

--- a/src/services/study/network-map.js
+++ b/src/services/study/network-map.js
@@ -92,7 +92,7 @@ export function fetchEquipmentsIds(
     nominalVoltages = null
 ) {
     console.info(
-        `Fetching equipments ids '${equipmentType}' of study '${studyUuid}' and node '${currentNodeUuid}' for ${substationsIds.length} substations ids and [${nominalVoltages}] nominal voltages.`
+        `Fetching equipments ids '${equipmentType}' of study '${studyUuid}' and node '${currentNodeUuid}' for ${substationsIds?.length} substations ids and [${nominalVoltages}] nominal voltages.`
     );
     let urlSearchParams = new URLSearchParams();
 

--- a/src/services/study/network-map.js
+++ b/src/services/study/network-map.js
@@ -86,7 +86,7 @@ export function fetchVoltageLevelEquipments(
 export function fetchEquipmentsIds(
     studyUuid,
     currentNodeUuid,
-    substationsIds = undefined,
+    substationsIds,
     equipmentType,
     inUpstreamBuiltParentNode,
     nominalVoltages = undefined

--- a/src/services/study/network-map.js
+++ b/src/services/study/network-map.js
@@ -89,7 +89,7 @@ export function fetchEquipmentsIds(
     substationsIds,
     equipmentType,
     inUpstreamBuiltParentNode,
-    nominalVoltages = null
+    nominalVoltages = undefined
 ) {
     console.info(
         `Fetching equipments ids '${equipmentType}' of study '${studyUuid}' and node '${currentNodeUuid}' for ${substationsIds?.length} substations ids and [${nominalVoltages}] nominal voltages.`

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -196,7 +196,7 @@ export const fetchDefaultParametersValues = () => {
     });
 };
 export const getQueryParamsList = (params, paramName) => {
-    if (params !== undefined && params.length > 0) {
+    if (params != null && Array.isArray(params) && params.length > 0) {
         const urlSearchParams = new URLSearchParams();
         params.forEach((id) => urlSearchParams.append(paramName, id));
         return urlSearchParams.toString();


### PR DESCRIPTION
This pull request fixes a null parameter issue in the `getQueryParamsList` function. The issue was causing errors when the function was called with a null parameter. This PR ensures that the function handles null parameters correctly, preventing any potential errors.