### PR TITLE
Refresh senstivity table in params when select saved params

### DIFF
--- a/src/components/dialogs/parameters/sensi/sensitivity-analysis-parameters.jsx
+++ b/src/components/dialogs/parameters/sensi/sensitivity-analysis-parameters.jsx
@@ -427,9 +427,9 @@ export const SensitivityAnalysisParameters = ({
                         };
                     }) ?? [],
             };
-            reset(values);
+            return values;
         },
-        [reset]
+        []
     );
 
     const initRowsCount = useCallback(() => {
@@ -514,6 +514,7 @@ export const SensitivityAnalysisParameters = ({
                                 keepDefaultValues: true,
                             }
                         );
+                        initRowsCount();
                     })
                     .catch((error) => {
                         console.error(error);
@@ -530,8 +531,10 @@ export const SensitivityAnalysisParameters = ({
 
     useEffect(() => {
         if (sensitivityAnalysisParams) {
-            fromSensitivityAnalysisParamsDataToFormValues(
-                sensitivityAnalysisParams
+            reset(
+                fromSensitivityAnalysisParamsDataToFormValues(
+                    sensitivityAnalysisParams
+                )
             );
             !isSubmitAction && initRowsCount();
         }
@@ -540,6 +543,7 @@ export const SensitivityAnalysisParameters = ({
         sensitivityAnalysisParams,
         initRowsCount,
         isSubmitAction,
+        reset,
     ]);
 
     const clear = useCallback(() => {

--- a/src/components/dialogs/parameters/sensi/sensitivity-analysis-parameters.jsx
+++ b/src/components/dialogs/parameters/sensi/sensitivity-analysis-parameters.jsx
@@ -526,7 +526,12 @@ export const SensitivityAnalysisParameters = ({
             }
             setOpenSelectParameterDialog(false);
         },
-        [snackError, fromSensitivityAnalysisParamsDataToFormValues, reset]
+        [
+            snackError,
+            fromSensitivityAnalysisParamsDataToFormValues,
+            reset,
+            initRowsCount,
+        ]
     );
 
     useEffect(() => {


### PR DESCRIPTION
Fixed bug:
 When we select a saved sensitivity params, the validate button is disabled and the computations count is not recalculated.
 