### PR TITLE
fix reset for modification dialog

### DIFF
--- a/src/components/dialogs/network-modifications/battery/modification/battery-modification-dialog.jsx
+++ b/src/components/dialogs/network-modifications/battery/modification/battery-modification-dialog.jsx
@@ -274,7 +274,7 @@ const BatteryModificationDialog = ({
             setValue,
             setValuesAndEmptyOthers,
             reset,
-            editData
+            editData,
         ]
     );
 

--- a/src/components/dialogs/network-modifications/battery/modification/battery-modification-dialog.jsx
+++ b/src/components/dialogs/network-modifications/battery/modification/battery-modification-dialog.jsx
@@ -256,9 +256,11 @@ const BatteryModificationDialog = ({
                         setDataFetchStatus(FetchStatus.SUCCEED);
                     })
                     .catch(() => {
-                        setBatteryToModify(null);
                         setDataFetchStatus(FetchStatus.FAILED);
-                        reset(emptyFormData);
+                        if (editData?.equipmentId !== equipmentId) {
+                            setBatteryToModify(null);
+                            reset(emptyFormData);
+                        }
                     });
             } else {
                 setValuesAndEmptyOthers();
@@ -272,6 +274,7 @@ const BatteryModificationDialog = ({
             setValue,
             setValuesAndEmptyOthers,
             reset,
+            editData
         ]
     );
 

--- a/src/components/dialogs/network-modifications/generator/modification/generator-modification-dialog.jsx
+++ b/src/components/dialogs/network-modifications/generator/modification/generator-modification-dialog.jsx
@@ -328,7 +328,7 @@ const GeneratorModificationDialog = ({
             getValues,
             setValue,
             setValuesAndEmptyOthers,
-            editData
+            editData,
         ]
     );
 

--- a/src/components/dialogs/network-modifications/generator/modification/generator-modification-dialog.jsx
+++ b/src/components/dialogs/network-modifications/generator/modification/generator-modification-dialog.jsx
@@ -310,9 +310,11 @@ const GeneratorModificationDialog = ({
                         setDataFetchStatus(FetchStatus.SUCCEED);
                     })
                     .catch(() => {
-                        setGeneratorToModify(null);
-                        reset(emptyFormData);
                         setDataFetchStatus(FetchStatus.FAILED);
+                        if (editData?.equipmentId !== equipmentId) {
+                            setGeneratorToModify(null);
+                            reset(emptyFormData);
+                        }
                     });
             } else {
                 setValuesAndEmptyOthers();
@@ -326,6 +328,7 @@ const GeneratorModificationDialog = ({
             getValues,
             setValue,
             setValuesAndEmptyOthers,
+            editData
         ]
     );
 

--- a/src/components/dialogs/network-modifications/line/modification/line-modification-dialog.jsx
+++ b/src/components/dialogs/network-modifications/line/modification/line-modification-dialog.jsx
@@ -328,9 +328,11 @@ const LineModificationDialog = ({
                         setDataFetchStatus(FetchStatus.SUCCEED);
                     })
                     .catch(() => {
-                        setLineToModify(null);
                         setDataFetchStatus(FetchStatus.FAILED);
-                        reset(emptyFormData);
+                        if (editData?.equipmentId !== equipmentId) {
+                            setLineToModify(null);
+                            reset(emptyFormData);
+                        }
                     });
             } else {
                 setLineToModify(null);

--- a/src/components/dialogs/network-modifications/shunt-compensator/modification/shunt-compensator-modification-dialog.jsx
+++ b/src/components/dialogs/network-modifications/shunt-compensator/modification/shunt-compensator-modification-dialog.jsx
@@ -177,19 +177,21 @@ const ShuntCompensatorModificationDialog = ({
                         setLoading(false);
                     })
                     .catch((error) => {
-                        setShuntCompensatorInfos(null);
                         setDataFetchStatus(FetchStatus.FAILED);
                         if (error.status === 404) {
                             setIdExists(true);
                         }
                         setLoading(false);
-                        reset(emptyFormData);
+                        if (editData?.equipmentId !== equipmentId) {
+                            setShuntCompensatorInfos(null);
+                            reset(emptyFormData);
+                        }
                     });
             } else {
                 setShuntCompensatorInfos(null);
             }
         },
-        [currentNode.id, snackError, studyUuid, reset, getValues]
+        [currentNode.id, snackError, studyUuid, reset, getValues, editData]
     );
 
     useEffect(() => {

--- a/src/components/dialogs/network-modifications/two-windings-transformer/modification/two-windings-transformer-modification-dialog.jsx
+++ b/src/components/dialogs/network-modifications/two-windings-transformer/modification/two-windings-transformer-modification-dialog.jsx
@@ -763,7 +763,7 @@ const TwoWindingsTransformerModificationDialog = ({
                         setDataFetchStatus(FetchStatus.FAILED);
                         if (editData?.equipmentId !== equipmentId) {
                             setTwtToModify(null);
-                            reset(emptyFormData)
+                            reset(emptyFormData);
                         }
                     });
             } else {
@@ -771,7 +771,7 @@ const TwoWindingsTransformerModificationDialog = ({
                 reset(emptyFormData, { keepDefaultValues: true });
             }
         },
-        [studyUuid, currentNodeUuid, selectedId, editData, reset, getValues, editData]
+        [studyUuid, currentNodeUuid, selectedId, editData, reset, getValues]
     );
 
     useEffect(() => {

--- a/src/components/dialogs/network-modifications/two-windings-transformer/modification/two-windings-transformer-modification-dialog.jsx
+++ b/src/components/dialogs/network-modifications/two-windings-transformer/modification/two-windings-transformer-modification-dialog.jsx
@@ -760,15 +760,18 @@ const TwoWindingsTransformerModificationDialog = ({
                         setDataFetchStatus(FetchStatus.SUCCEED);
                     })
                     .catch(() => {
-                        setTwtToModify(null);
                         setDataFetchStatus(FetchStatus.FAILED);
+                        if (editData?.equipmentId !== equipmentId) {
+                            setTwtToModify(null);
+                            reset(emptyFormData)
+                        }
                     });
             } else {
                 setTwtToModify(null);
                 reset(emptyFormData, { keepDefaultValues: true });
             }
         },
-        [studyUuid, currentNodeUuid, selectedId, editData, reset, getValues]
+        [studyUuid, currentNodeUuid, selectedId, editData, reset, getValues, editData]
     );
 
     useEffect(() => {

--- a/src/components/dialogs/network-modifications/voltage-level/modification/voltage-level-modification-dialog.jsx
+++ b/src/components/dialogs/network-modifications/voltage-level/modification/voltage-level-modification-dialog.jsx
@@ -162,16 +162,18 @@ const VoltageLevelModificationDialog = ({
                         }
                     })
                     .catch(() => {
-                        setVoltageLevelInfos(null);
                         setDataFetchStatus(FetchStatus.FAILED);
-                        reset(emptyFormData);
+                        if (editData?.equipmentId !== equipmentId) {
+                            setVoltageLevelInfos(null);
+                            reset(emptyFormData);
+                        }
                     });
             } else {
                 setVoltageLevelInfos(null);
                 reset(emptyFormData, { keepDefaultValues: true });
             }
         },
-        [studyUuid, currentNodeUuid, reset, getValues]
+        [studyUuid, currentNodeUuid, reset, getValues, editData]
     );
 
     useEffect(() => {

--- a/src/components/dialogs/network-modifications/vsc/modification/vsc-modification-dialog.tsx
+++ b/src/components/dialogs/network-modifications/vsc/modification/vsc-modification-dialog.tsx
@@ -245,8 +245,10 @@ const VscModificationDialog: React.FC<any> = ({
                     })
                     .catch((_error) => {
                         setDataFetchStatus(FetchStatus.FAILED);
-                        setVcsToModify(null);
-                        reset(emptyFormData);
+                        if (editData?.equipmentId !== equipmentId) {
+                            setVcsToModify(null);
+                            reset(emptyFormData);
+                        }
                     });
             } else {
                 setValuesAndEmptyOthers();
@@ -260,6 +262,7 @@ const VscModificationDialog: React.FC<any> = ({
             getValues,
             reset,
             setValuesAndEmptyOthers,
+            editData,
         ]
     );
     useEffect(() => {

--- a/src/components/dialogs/network-modifications/vsc/modification/vsc-modification-dialog.tsx
+++ b/src/components/dialogs/network-modifications/vsc/modification/vsc-modification-dialog.tsx
@@ -174,15 +174,15 @@ const VscModificationDialog: React.FC<any> = ({
     );
 
     const onEquipmentIdChange = useCallback(
-        (equipementId: string | null) => {
-            if (equipementId) {
+        (equipmentId: string | null) => {
+            if (equipmentId) {
                 setDataFetchStatus(FetchStatus.RUNNING);
                 fetchNetworkElementInfos(
                     studyUuid,
                     currentNodeUuid,
                     EQUIPMENT_TYPES.HVDC_LINE,
                     EQUIPMENT_INFOS_TYPES.FORM.type,
-                    equipementId,
+                    equipmentId,
                     true
                 )
                     .then((value: any) => {
@@ -243,7 +243,7 @@ const VscModificationDialog: React.FC<any> = ({
                         }));
                         setDataFetchStatus(FetchStatus.SUCCEED);
                     })
-                    .catch((_error) => {
+                    .catch(() => {
                         setDataFetchStatus(FetchStatus.FAILED);
                         if (editData?.equipmentId !== equipmentId) {
                             setVcsToModify(null);


### PR DESCRIPTION
fix a bug on modification dialog, 
when modifying an element on an not build node, if coming back to the editor the value disappeared.
