### PR TITLE
[FIX] Side 2 Connection Position previous values not shown in line modification

### DIFF
--- a/src/components/dialogs/connectivity/branch-connectivity-form.tsx
+++ b/src/components/dialogs/connectivity/branch-connectivity-form.tsx
@@ -55,7 +55,7 @@ const BranchConnectivityForm: FunctionComponent<BranchConnectivityFormProps> = (
             withPosition={true}
             isEquipmentModification={isModification}
             previousValues={{
-                connectablePosition: previousValues?.connectablePosition12,
+                connectablePosition: previousValues?.connectablePosition2,
                 terminalConnected: previousValues?.terminal2Connected,
             }}
         />


### PR DESCRIPTION
FIX BUG from the previous PR: https://github.com/gridsuite/gridstudy-app/pull/2243