### PR TITLE
Fix warning provider init in Select component for Sensi

### DIFF
--- a/src/components/dialogs/parameters/sensi/sensitivity-analysis-parameters.jsx
+++ b/src/components/dialogs/parameters/sensi/sensitivity-analysis-parameters.jsx
@@ -106,7 +106,7 @@ export const SensitivityAnalysisParameters = ({ parametersBackend, setHaveDirtyF
 
     const emptyFormData = useMemo(() => {
         return {
-            [PROVIDER]: null,
+            [PROVIDER]: '',
             [FLOW_FLOW_SENSITIVITY_VALUE_THRESHOLD]: 0,
             [ANGLE_FLOW_SENSITIVITY_VALUE_THRESHOLD]: 0,
             [FLOW_VOLTAGE_SENSITIVITY_VALUE_THRESHOLD]: 0,


### PR DESCRIPTION
warning: MUI: You have provided an out-of-range value `null` for the select component.
Consider providing a value that matches one of the available options or ''. The available values are `OpenLoadFlow`.