### PR TITLE
Fix csv export filename not translatable warning

### DIFF
--- a/src/components/spreadsheet/export-csv.tsx
+++ b/src/components/spreadsheet/export-csv.tsx
@@ -22,6 +22,8 @@ interface CsvExportProps {
     skipColumnHeaders?: boolean;
 }
 
+const DEFAULT_FILENAME = 'csv-export';
+
 export const CsvExport: FunctionComponent<CsvExportProps> = ({
     gridRef,
     columns,
@@ -36,7 +38,7 @@ export const CsvExport: FunctionComponent<CsvExportProps> = ({
         const localisedTabName =
             (Object.keys(intl.messages).find((key) => key === tableName)
                 ? intl.formatMessage({ id: tableName })
-                : tableName) ?? '';
+                : tableName) ?? DEFAULT_FILENAME;
         return localisedTabName
             .trim()
             .replace(/[\\/:"*?<>|\s]/g, '-') // Removes the filesystem sensible characters


### PR DESCRIPTION
Fixes this type of warnings when exporting a CSV dataset whose name is not translatable :

    Tab Current Violations from Loadflow results :
        Error: [@formatjs/intl Error MISSING_TRANSLATION] Missing message: "Current violations" for locale "en", using id as fallback.
    Tab Voltage violations from Loadflow results :
        Error: [@formatjs/intl Error MISSING_TRANSLATION] Missing message: "Voltage violations" for locale "en", using id as fallback.
    Tab Status from Loadflow results:
        Error: [@formatjs/intl Error MISSING_TRANSLATION] Missing message: "Status" for locale "en", using id as fallback.

By checking if the provided filename is in intl messages, if it's not, use it raw. If it's undefined a default filename is used instead