### PR TITLE
corrects display rounding

### DIFF
--- a/src/components/custom-aggrid/hooks/use-custom-aggrid-comparator-filter.ts
+++ b/src/components/custom-aggrid/hooks/use-custom-aggrid-comparator-filter.ts
@@ -9,7 +9,7 @@ import { ChangeEvent, useMemo } from 'react';
 import { useSnackMessage } from '@gridsuite/commons-ui';
 import { SelectChangeEvent } from '@mui/material/Select/SelectInput';
 import { computeTolerance } from '../../../hooks/use-aggrid-local-row-filter';
-import { countDecimalPlaces } from '../../../utils/rounding';
+import { countDecimalPlacesFromString } from '../../../utils/rounding';
 import { useCustomAggridFilter } from './use-custom-aggrid-filter';
 import { FilterParams } from '../custom-aggrid-header.type';
 
@@ -43,7 +43,7 @@ export const useCustomAggridComparatorFilter = (field: string, filterParams: Fil
 
     const decimalAfterDot = useMemo(() => {
         if (isNumberInput) {
-            let decimalAfterDot = countDecimalPlaces(Number(selectedFilterData));
+            let decimalAfterDot: number = countDecimalPlacesFromString(String(selectedFilterData));
             if (decimalAfterDot >= 13) {
                 snackWarning({
                     headerId: 'filter.warnRounding',


### PR DESCRIPTION
When a user enters a number as filter value whch has 0s after the dot the rounding displayed is wrong : 

12.000 should display "rounding to 0.0001" but it displays "Rounding to the nearest unit"