### PR TITLE
Disable developer mode for limit reductions

### DIFF
--- a/src/components/dialogs/parameters/common/limitreductions/columns-definitions.ts
+++ b/src/components/dialogs/parameters/common/limitreductions/columns-definitions.ts
@@ -59,7 +59,7 @@ export enum TAB_VALUES {
 
 export const TAB_INFO = [
     { label: TAB_VALUES[TAB_VALUES.General], developerModeOnly: false },
-    { label: TAB_VALUES[TAB_VALUES.LimitReductions], developerModeOnly: true },
+    { label: TAB_VALUES[TAB_VALUES.LimitReductions], developerModeOnly: false },
 ];
 
 export interface IColumnsDef {


### PR DESCRIPTION
Reverts a previous revert to restore dev (gridsuite/gridstudy-app#2489)