### PR TITLE
Fix: Restore Limit Reduction Tab out of devMode

### DIFF
--- a/src/components/dialogs/parameters/loadflow/load-flow-parameters-content.tsx
+++ b/src/components/dialogs/parameters/loadflow/load-flow-parameters-content.tsx
@@ -22,14 +22,12 @@ const LoadFlowParametersContent = ({
     currentProvider,
     specificParameters,
     params,
-    enableDeveloperMode,
     defaultLimitReductions,
 }: {
     selectedTab: TAB_VALUES;
     currentProvider: string;
     specificParameters: ParameterDescription[];
     params: LoadFlowParametersInfos | null;
-    enableDeveloperMode: boolean;
     defaultLimitReductions: ILimitReductionsByVoltageLevel[];
 }) => {
     return (
@@ -50,24 +48,20 @@ const LoadFlowParametersContent = ({
                     <TabPanel value={selectedTab} index={TAB_VALUES.GENERAL}>
                         <LoadFlowGeneralParameters provider={currentProvider} specificParams={specificParameters} />
                     </TabPanel>
-                    {enableDeveloperMode && (
-                        <TabPanel value={selectedTab} index={TAB_VALUES.LIMIT_REDUCTIONS}>
-                            <Grid container sx={{ width: '100%' }}>
-                                {currentProvider === 'OpenLoadFlow' ? (
-                                    <LimitReductionsTableForm
-                                        limits={params?.limitReductions ?? defaultLimitReductions}
-                                    />
-                                ) : (
-                                    <ParameterLineSlider
-                                        paramNameId={PARAM_LIMIT_REDUCTION}
-                                        label="LimitReduction"
-                                        marks={alertThresholdMarks}
-                                        minValue={MIN_VALUE_ALLOWED_FOR_LIMIT_REDUCTION}
-                                    />
-                                )}
-                            </Grid>
-                        </TabPanel>
-                    )}
+                    <TabPanel value={selectedTab} index={TAB_VALUES.LIMIT_REDUCTIONS}>
+                        <Grid container sx={{ width: '100%' }}>
+                            {currentProvider === 'OpenLoadFlow' ? (
+                                <LimitReductionsTableForm limits={params?.limitReductions ?? defaultLimitReductions} />
+                            ) : (
+                                <ParameterLineSlider
+                                    paramNameId={PARAM_LIMIT_REDUCTION}
+                                    label="LimitReduction"
+                                    marks={alertThresholdMarks}
+                                    minValue={MIN_VALUE_ALLOWED_FOR_LIMIT_REDUCTION}
+                                />
+                            )}
+                        </Grid>
+                    </TabPanel>
                 </Grid>
             </Grid>
         </Box>

--- a/src/components/dialogs/parameters/loadflow/load-flow-parameters-header.tsx
+++ b/src/components/dialogs/parameters/loadflow/load-flow-parameters-header.tsx
@@ -19,13 +19,11 @@ const LoadFlowParametersHeader = ({
     selectedTab,
     handleTabChange,
     tabIndexesWithError,
-    enableDeveloperMode,
     formattedProviders,
 }: {
     selectedTab: string;
     handleTabChange: (event: React.SyntheticEvent, newValue: TAB_VALUES) => void;
     tabIndexesWithError: TAB_VALUES[];
-    enableDeveloperMode: boolean;
     formattedProviders: { id: string; label: string }[];
 }) => (
     <Box sx={{ flexGrow: 0, paddingLeft: 1, paddingTop: 1 }}>
@@ -53,13 +51,11 @@ const LoadFlowParametersHeader = ({
                         value={TAB_VALUES.GENERAL}
                         sx={getTabStyle(tabIndexesWithError, TAB_VALUES.GENERAL)}
                     />
-                    {enableDeveloperMode && (
-                        <Tab
-                            label={<FormattedMessage id={TAB_VALUES.LIMIT_REDUCTIONS} />}
-                            value={TAB_VALUES.LIMIT_REDUCTIONS}
-                            sx={getTabStyle(tabIndexesWithError, TAB_VALUES.LIMIT_REDUCTIONS)}
-                        />
-                    )}
+                    <Tab
+                        label={<FormattedMessage id={TAB_VALUES.LIMIT_REDUCTIONS} />}
+                        value={TAB_VALUES.LIMIT_REDUCTIONS}
+                        sx={getTabStyle(tabIndexesWithError, TAB_VALUES.LIMIT_REDUCTIONS)}
+                    />
                 </Tabs>
             </Grid>
         </Grid>

--- a/src/components/dialogs/parameters/loadflow/load-flow-parameters.tsx
+++ b/src/components/dialogs/parameters/loadflow/load-flow-parameters.tsx
@@ -327,7 +327,6 @@ const LoadFlowParameters: FunctionComponent<{
                             selectedTab={selectedTab}
                             handleTabChange={handleTabChange}
                             tabIndexesWithError={tabIndexesWithError}
-                            enableDeveloperMode={enableDeveloperMode}
                             formattedProviders={formattedProviders}
                         />
                         <LoadFlowParametersContent
@@ -335,7 +334,6 @@ const LoadFlowParameters: FunctionComponent<{
                             currentProvider={currentProvider ?? ''}
                             specificParameters={specificParameters}
                             params={params}
-                            enableDeveloperMode={enableDeveloperMode}
                             defaultLimitReductions={defaultLimitReductions}
                         />
                         <Box sx={{ flexGrow: 0 }}>


### PR DESCRIPTION
fix(LoadFlowParameters): Limit Reduction Tab was out of the developer mode before rhf migration