### PR TITLE
Remove node uuid, rootnetwork uuid when fetching dynamic models

### DIFF
--- a/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/model-filter.tsx
+++ b/src/components/dialogs/parameters/dynamicsimulation/curve/dialog/model-filter.tsx
@@ -7,7 +7,7 @@
 
 import { FormattedMessage, IntlShape, useIntl } from 'react-intl';
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import { Grid, Box, Typography, Theme } from '@mui/material';
+import { Box, Grid, Theme, Typography } from '@mui/material';
 import CheckboxSelect from '../common/checkbox-select';
 import CheckboxTreeview, { GetSelectedItemsHandle } from '../common/checkbox-treeview';
 import { lighten } from '@mui/material/styles';
@@ -170,8 +170,6 @@ const ModelFilter = forwardRef<GetSelectedVariablesHandle, ModelFilterProps>(
         const intl = useIntl();
 
         const studyUuid = useSelector((state: AppState) => state.studyUuid);
-        const currentNode = useSelector((state: AppState) => state.currentTreeNode);
-        const currentRootNetworkUuid = useSelector((state: AppState) => state.currentRootNetwork);
 
         const [allModels, setAllModels] = useState<DynamicSimulationModel[]>([]);
         const [allVariables, setAllVariables] = useState<
@@ -217,26 +215,21 @@ const ModelFilter = forwardRef<GetSelectedVariablesHandle, ModelFilterProps>(
             [variables, selectedModels, associatedModels]
         );
 
-        // fetch all associated models and variables for current node and study
+        // fetch all associated models and variables for study
         useEffect(() => {
-            if (!currentNode?.id || !currentRootNetworkUuid) {
-                return;
-            }
-            fetchDynamicSimulationModels(studyUuid, currentNode.id, currentRootNetworkUuid).then(
-                (models: DynamicSimulationModelBack[]) => {
-                    setAllModels(
-                        models.map((model) => ({
-                            name: model.modelName,
-                            equipmentType: model.equipmentType,
-                        }))
-                    );
+            fetchDynamicSimulationModels(studyUuid).then((models: DynamicSimulationModelBack[]) => {
+                setAllModels(
+                    models.map((model) => ({
+                        name: model.modelName,
+                        equipmentType: model.equipmentType,
+                    }))
+                );
 
-                    // transform models to variables tree representation
-                    const variablesTree = modelsToVariablesTree(models);
-                    setAllVariables(variablesTree);
-                }
-            );
-        }, [studyUuid, currentNode?.id, currentRootNetworkUuid]);
+                // transform models to variables tree representation
+                const variablesTree = modelsToVariablesTree(models);
+                setAllVariables(variablesTree);
+            });
+        }, [studyUuid]);
 
         // expose some api for the component by using ref
         useImperativeHandle(

--- a/src/services/study/dynamic-simulation.ts
+++ b/src/services/study/dynamic-simulation.ts
@@ -24,7 +24,7 @@ export function startDynamicSimulation(
     dynamicSimulationConfiguration?: any
 ) {
     console.info(
-        `Running dynamic simulation on '${studyUuid}' on root nerwork '${currentRootNetworkUuid}' and node '${currentNodeUuid}' ...`
+        `Running dynamic simulation on '${studyUuid}' on root network '${currentRootNetworkUuid}' and node '${currentNodeUuid}' ...`
     );
     const startDynamicSimulationUrl = `${getStudyUrlWithNodeUuidAndRootNetworkUuid(
         studyUuid,
@@ -75,7 +75,7 @@ export function fetchDynamicSimulationResultTimeSeries(
     timeSeriesNames: string[]
 ) {
     console.info(
-        `Fetching dynamic simulation time series result on '${studyUuid}' on root nerwork '${currentRootNetworkUuid}' and node '${currentNodeUuid}' ...`
+        `Fetching dynamic simulation time series result on '${studyUuid}' on root network '${currentRootNetworkUuid}' and node '${currentNodeUuid}' ...`
     );
 
     // Add params to Url
@@ -92,12 +92,9 @@ export function fetchDynamicSimulationResultTimeSeries(
     return backendFetchJson(url);
 }
 
-export function fetchDynamicSimulationModels(studyUuid: UUID | null, nodeUuid: UUID, rootNetworkUuid: UUID) {
-    console.info(
-        `Fetching dynamic simulation models on '${studyUuid}' on root network '${rootNetworkUuid}' and node '${nodeUuid}' ...`
-    );
-    const url =
-        getStudyUrlWithNodeUuidAndRootNetworkUuid(studyUuid, nodeUuid, rootNetworkUuid) + '/dynamic-simulation/models';
+export function fetchDynamicSimulationModels(studyUuid: UUID | null) {
+    console.info(`Fetching dynamic simulation models on '${studyUuid}' ...`);
+    const url = getStudyUrl(studyUuid) + '/dynamic-simulation/models';
     console.debug(url);
     return backendFetchJson(url);
 }


### PR DESCRIPTION
This PR is a FIX for the regression from PR of root network uuid : https://github.com/gridsuite/gridstudy-app/pull/2542