### PR TITLE
Remove the useless debounce in useParameterState

### DIFF
--- a/src/components/dialogs/parameters/parameters.tsx
+++ b/src/components/dialogs/parameters/parameters.tsx
@@ -581,9 +581,10 @@ export function useParameterState(paramName: UseParameterStateParamName) {
         setParamLocalState(paramGlobalState);
     }, [paramGlobalState]);
 
-    const backendupdateConfigParameterCb = useCallback(
-        (paramName: string, newParams: any) => {
-            updateConfigParameter(paramName, newParams).catch((error) => {
+    const handleChangeParamLocalState = useCallback(
+        (value: any) => {
+            setParamLocalState(value);
+            updateConfigParameter(paramName, value).catch((error) => {
                 setParamLocalState(paramGlobalState);
                 snackError({
                     messageTxt: error.message,
@@ -591,17 +592,7 @@ export function useParameterState(paramName: UseParameterStateParamName) {
                 });
             });
         },
-        [paramGlobalState, snackError]
-    );
-
-    const debouncedBackendupdateConfigParameterCb = useDebounce(backendupdateConfigParameterCb, 1000);
-
-    const handleChangeParamLocalState = useCallback(
-        (value: any) => {
-            setParamLocalState(value);
-            debouncedBackendupdateConfigParameterCb(paramName, value);
-        },
-        [debouncedBackendupdateConfigParameterCb, paramName]
+        [paramName, snackError, paramGlobalState]
     );
 
     return [paramLocalState, handleChangeParamLocalState];


### PR DESCRIPTION
The debounce is only used on a field that will be removed soon.
Removing the debounce helps the language and theme change, and fixes an issue where parameters would not be saved if the parent component do not exist after the debounce timer.