### PR TITLE
Keep zoom pan on NAD and SLD when changing views

### DIFF
--- a/src/components/diagrams/diagram-pane.tsx
+++ b/src/components/diagrams/diagram-pane.tsx
@@ -1039,7 +1039,7 @@ export function DiagramPane({
         [currentNode]
     );
     return (
-        <AutoSizer>
+        <AutoSizer doNotBailOutOnEmptyChildren>
             {({ width, height }) => (
                 <Box
                     sx={mergeSx(styles.availableDiagramSurfaceArea, fullScreenDiagram?.id && styles.fullscreen)}


### PR DESCRIPTION
feat(DiagramPane): set doNotBailOutOnEmptyChildren on Autosizer to avoid to unmount children component when Map view and diagrams are hidden.