### PR TITLE
Refactor: Memoize `showInSpreadsheet` callback for render optimization

### DIFF
--- a/src/components/diagrams/singleLineDiagram/single-line-diagram-content.tsx
+++ b/src/components/diagrams/singleLineDiagram/single-line-diagram-content.tsx
@@ -119,7 +119,7 @@ function applyInvalidStyles(svgContainer: HTMLElement) {
 }
 
 function SingleLineDiagramContent(props: SingleLineDiagramContentProps) {
-    const { diagramSizeSetter, studyUuid, visible } = props;
+    const { diagramSizeSetter, studyUuid, visible, showInSpreadsheet } = props;
     const theme = useTheme();
     const dispatch = useDispatch();
     const MenuBranch = withOperatingStatusMenu(BaseEquipmentMenu);
@@ -273,15 +273,15 @@ function SingleLineDiagramContent(props: SingleLineDiagramContentProps) {
         });
     }, []);
 
-    const handleViewInSpreadsheet = () => {
+    const handleViewInSpreadsheet = useCallback(() => {
         if (equipmentMenu.equipmentId && equipmentMenu.equipmentType) {
-            props.showInSpreadsheet({
+            showInSpreadsheet({
                 equipmentId: equipmentMenu.equipmentId,
                 equipmentType: convertToEquipmentType(equipmentMenu.equipmentType),
             });
         }
         closeEquipmentMenu();
-    };
+    }, [closeEquipmentMenu, equipmentMenu.equipmentId, equipmentMenu.equipmentType, showInSpreadsheet]);
 
     const removeEquipment = useCallback(
         (equipmentType: string, equipmentId: string) => {

--- a/src/components/map-viewer.jsx
+++ b/src/components/map-viewer.jsx
@@ -159,15 +159,18 @@ const MapViewer = ({
         [openDiagramView, isInDrawingMode]
     );
 
-    function showInSpreadsheet(equipment) {
-        let newTableEquipment = {
-            id: equipment.equipmentId,
-            type: equipment.equipmentType,
-            changed: !tableEquipment.changed,
-        };
-        onTableEquipementChanged(newTableEquipment);
-        onChangeTab(1); // switch to spreadsheet view
-    }
+    const showInSpreadsheet = useCallback(
+        (equipment) => {
+            let newTableEquipment = {
+                id: equipment.equipmentId,
+                type: equipment.equipmentType,
+                changed: !tableEquipment.changed,
+            };
+            onTableEquipementChanged(newTableEquipment);
+            onChangeTab(1); // switch to spreadsheet view
+        },
+        [onChangeTab, onTableEquipementChanged, tableEquipment.changed]
+    );
 
     const onDrawingModeEnter = useCallback((active) => {
         setDrawingMode(active);

--- a/src/components/menus/base-equipment-menu.tsx
+++ b/src/components/menus/base-equipment-menu.tsx
@@ -21,6 +21,7 @@ import { isNodeReadOnly } from '../graph/util/model-functions';
 import { CustomMenuItem, CustomNestedMenuItem } from '../utils/custom-nested-menu';
 import { Equipment, EquipmentType } from '@gridsuite/commons-ui';
 import { AppState } from 'redux/reducer';
+import { useCallback } from 'react';
 
 const styles = {
     menuItem: {
@@ -46,12 +47,12 @@ const ViewInSpreadsheetItem = ({
     itemText: string;
     handleViewInSpreadsheet: HandleViewInSpreadsheet;
 }) => {
+    const handleClick = useCallback(() => {
+        handleViewInSpreadsheet(equipmentType, equipmentId);
+    }, [equipmentId, equipmentType, handleViewInSpreadsheet]);
+
     return (
-        <CustomMenuItem
-            sx={styles.menuItem}
-            onClick={() => handleViewInSpreadsheet(equipmentType, equipmentId)}
-            selected={false}
-        >
+        <CustomMenuItem sx={styles.menuItem} onClick={handleClick} selected={false}>
             <ListItemIcon>
                 <TableChartIcon />
             </ListItemIcon>

--- a/src/components/network/network-map-tab.tsx
+++ b/src/components/network/network-map-tab.tsx
@@ -333,13 +333,16 @@ export const NetworkMapTab = ({
         setEquipmentMenu({ display: false });
     }
 
-    function handleViewInSpreadsheet(equipmentType: EquipmentType, equipmentId: string) {
-        showInSpreadsheet({
-            equipmentType: equipmentType,
-            equipmentId: equipmentId,
-        });
-        closeEquipmentMenu();
-    }
+    const handleViewInSpreadsheet = useCallback(
+        (equipmentType: EquipmentType, equipmentId: string) => {
+            showInSpreadsheet({
+                equipmentType: equipmentType,
+                equipmentId: equipmentId,
+            });
+            closeEquipmentMenu();
+        },
+        [showInSpreadsheet]
+    );
 
     const handleDeleteEquipment = useCallback(
         (equipmentType: EquipmentType | null, equipmentId: string) => {


### PR DESCRIPTION
refactor(): memoize showInSpreadsheet function to avoid savage updates and rerenders whenever MapViewer or NetworkMapTab is rendered