### PR TITLE
Don't save deleted contingencies list when saving favorites

### DIFF
--- a/src/components/dialogs/contingency-list-selector.jsx
+++ b/src/components/dialogs/contingency-list-selector.jsx
@@ -75,20 +75,27 @@ const ContingencyListSelector = (props) => {
     );
 
     useEffect(() => {
-        setSimulatedContingencyCount(null);
-        var discardResult = false;
-        if (isNodeBuilt(currentNode) && props.open) {
-            fetchContingencyCount(
-                props.studyUuid,
-                currentNode.id,
-                currentRootNetworkUuid,
-                checkedContingencyList.map((c) => c.id)
-            ).then((contingencyCount) => {
-                if (!discardResult) {
-                    setSimulatedContingencyCount(contingencyCount);
-                }
-            });
+        if (!isNodeBuilt(currentNode) || !props.open) {
+            return;
         }
+
+        if (checkedContingencyList.length === 0) {
+            setSimulatedContingencyCount(0);
+            return;
+        }
+
+        setSimulatedContingencyCount(null);
+        let discardResult = false;
+        fetchContingencyCount(
+            props.studyUuid,
+            currentNode.id,
+            currentRootNetworkUuid,
+            checkedContingencyList.map((c) => c.id)
+        ).then((contingencyCount) => {
+            if (!discardResult) {
+                setSimulatedContingencyCount(contingencyCount);
+            }
+        });
         return () => {
             discardResult = true;
         };
@@ -144,7 +151,10 @@ const ContingencyListSelector = (props) => {
     const addFavorites = (favorites) => {
         if (favorites && favorites.length > 0) {
             // avoid duplicates here
-            const newFavoriteIdsSet = new Set([...favoriteContingencyListUuids, ...favorites.map((item) => item.id)]);
+            const newFavoriteIdsSet = new Set([
+                ...contingencyList.map((e) => e.id),
+                ...favorites.map((item) => item.id),
+            ]);
             saveFavorites(Array.from([...newFavoriteIdsSet]));
         }
         setFavoriteSelectorOpen(false);


### PR DESCRIPTION
* When opening the favorite window, **don't** fetch on the server if nothing is selected
* Similarly to remove from favorite (see code below), save the contingency list filtered with removed contingency lists in GridExplore instead of always adding new contingencies lists to existing lists.
https://github.com/gridsuite/gridstudy-app/blob/1d98ae7285b7eb922396a609f03483598467a22f/src/components/dialogs/contingency-list-selector.jsx#L144

For the moment, we decided not to support having more than 100 contingency lists so I did not put the contingencies uuids in the body of the request. We anyway have limitations on the server as it's a varchar(4000) in DB and we can't save much more than 100 contingencies in this.