### PR TITLE
Fixes result tab deps cycles

### DIFF
--- a/src/components/result-view-tab.tsx
+++ b/src/components/result-view-tab.tsx
@@ -29,6 +29,7 @@ import { StateEstimationResultTab } from './results/stateestimation/state-estima
 import DynamicSecurityAnalysisResultTab from './results/dynamic-security-analysis/dynamic-security-analysis-result-tab';
 import { usePrevious } from '@gridsuite/commons-ui';
 import { useParameterState } from './dialogs/parameters/use-parameters-state';
+import { IService } from './result-view-tab.type';
 
 const styles = {
     table: {
@@ -51,13 +52,6 @@ interface IResultViewTabProps {
     openVoltageLevelDiagram: (voltageLevelId: string) => void;
     disabled: boolean;
     view: string;
-}
-
-export interface IService {
-    id: string;
-    computingType: ComputingType[];
-    displayed: boolean;
-    renderResult: React.ReactNode;
 }
 
 /**

--- a/src/components/result-view-tab.type.ts
+++ b/src/components/result-view-tab.type.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import ComputingType from './computing-status/computing-type';
+
+export interface IService {
+    id: string;
+    computingType: ComputingType[];
+    displayed: boolean;
+    renderResult: React.ReactNode;
+}

--- a/src/components/results/use-results-tab.ts
+++ b/src/components/results/use-results-tab.ts
@@ -6,12 +6,12 @@
  */
 
 import ComputingType from 'components/computing-status/computing-type';
-import { IService } from 'components/result-view-tab';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { AppState } from 'redux/reducer';
 import { ShortCircuitAnalysisResultTabs } from './shortcircuit/shortcircuit-analysis-result.type';
 import { StudyView } from 'components/utils/utils';
+import { IService } from '../result-view-tab.type';
 
 export enum ResultsTabsRootLevel {
     LOAD_FLOW = 0,


### PR DESCRIPTION
Solves : 

- result-view-tab.tsx
  10:1  error  Dependency cycle via ../use-results-tab:15  import/no-cycle
  
- shortcircuit-analysis-result-tab.tsx
  11:1  error  Dependency cycle via components/result-view-tab:9  import/no-cycle

- use-results-tab.ts
  9:1  error  Dependency cycle detected  import/no-cycle