### PR TITLE
Fix map not loading sometimes

### DIFF
--- a/src/components/network/network-map-tab.tsx
+++ b/src/components/network/network-map-tab.tsx
@@ -857,7 +857,8 @@ export const NetworkMapTab = ({
             return;
         }
         // when root network has just been changed, we reset map equipment and geo data, they will be loaded as if we were opening a new study
-        if (previousCurrentRootNetworkUuid !== currentRootNetworkUuid) {
+        // DO NOT BREAK AT FIRST LOADING (previousCurrentRootNetworkUuid=null)
+        if (previousCurrentRootNetworkUuid && previousCurrentRootNetworkUuid !== currentRootNetworkUuid) {
             setInitialized(false);
             setIsRootNodeGeoDataLoaded(false);
             dispatch(resetMapEquipment());


### PR DESCRIPTION
fix(NetworkMapTab): Sometimes, the tree is loaded quicker than the network map tab component. Then isNetworkModificationTreeUpToDate is true and doesn't changes later.  This avoid a necessary proc of the effect which is necessary to call updateMapEquipmentsAndGeoData. If the effect is called only once then previousCurrentRootNetworkUuid is null and we never initialize geodata and mapEquipments