### PR TITLE
Fix Prettier to work with IDE plugins

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-node-options=--experimental-strip-types

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -5,9 +5,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import type { Config } from 'prettier';
-
-export default {
+// @ts-check
+/**
+ * @see https://prettier.io/docs/configuration
+ * @type {import("prettier").Config}
+ * @todo Pass this file in typescript when the IDEs plugins support it<ul>
+ *       <li>https://github.com/prettier/prettier-vscode/issues/3623</li>
+ *       <li>https://youtrack.jetbrains.com/issue/WEB-71713/Support-for-prettier.config.ts</li></ul>
+ */
+const config = {
     trailingComma: 'es5',
     tabWidth: 4,
     printWidth: 120,
@@ -24,4 +30,5 @@ export default {
             options: { tabWidth: 2 },
         },
     ],
-} satisfies Config;
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
         "jest.setup.ts",
         // We must list config files in typescript because needed by prettier when called by eslint as plugin
         "jest.config.ts",
-        "prettier.config.ts",
+        "prettier.config.js",
         "vite.config.ts"
     ]
 }


### PR DESCRIPTION
The Prettier plugin in IDEs ([VSCode](https://github.com/prettier/prettier-vscode/issues/3623), [~IntelliJ~ WebStorm](https://youtrack.jetbrains.com/issue/WEB-71713/Support-for-prettier.config.ts)) don't support the experimental `prettier.config.ts` format.

Reverting to `prettier.config.js` until the plugins support it.