### PR TITLE
[Dynamic simulation] Button close of plot no longer works

### DIFF
--- a/src/components/results/dynamicsimulation/dynamic-simulation-result-time-series.tsx
+++ b/src/components/results/dynamicsimulation/dynamic-simulation-result-time-series.tsx
@@ -7,7 +7,7 @@
 
 import CloseIcon from '@mui/icons-material/Close';
 import AddIcon from '@mui/icons-material/Add';
-import { Box, LinearProgress, Theme } from '@mui/material';
+import { Box, Grid, LinearProgress, Theme } from '@mui/material';
 import DynamicSimulationResultChart from './timeseries/dynamic-simulation-result-chart';
 import { memo, SyntheticEvent, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -27,10 +27,11 @@ import { DropResult } from '@hello-pangea/dnd';
 const styles = {
     root: {
         height: '100%',
+        maxWidth: '100vw',
     },
     addButton: (theme: Theme) => ({
         borderRadius: '50%',
-        marginRight: theme.spacing(10),
+        marginRight: theme.spacing(2),
         color: theme.palette.primary.main,
     }),
     loader: {
@@ -123,61 +124,65 @@ const DynamicSimulationResultTimeSeries = memo(function ({
                 </Box>
             )}
             <Overlay message={overlayMessage}>
-                <Box sx={styles.root}>
-                    <Box sx={{ display: 'flex', flexDirection: 'row' }}>
-                        {/* tab headers */}
-                        <DroppableTabs
-                            id={'1'}
-                            value={selectedIndex}
-                            onChange={handleTabsChange}
-                            tabsRender={() =>
-                                tabs.map((tab, index) => {
-                                    return (
-                                        <DraggableTab
-                                            key={`tab-${tab.id}`}
-                                            id={`tab-${index}`}
-                                            index={index}
-                                            value={index}
-                                            label={
-                                                <span
-                                                    style={{
-                                                        whiteSpace: 'nowrap',
-                                                    }}
-                                                >
-                                                    {`${intl.formatMessage({
-                                                        id: 'DynamicSimulationResultTab',
-                                                    })} ${tab.id}`}
-                                                    <TooltipIconButton
-                                                        tooltip={intl.formatMessage({
-                                                            id: 'DynamicSimulationCloseTab',
-                                                        })}
-                                                        size="small"
-                                                        component="span"
-                                                        onClick={handleClose(index)}
+                <Grid sx={styles.root}>
+                    {/* tab headers */}
+                    <Grid container direction="row" wrap="nowrap" item>
+                        <Grid item sx={{ overflow: 'hidden' }}>
+                            <DroppableTabs
+                                id={'1'}
+                                value={selectedIndex}
+                                onChange={handleTabsChange}
+                                tabsRender={() =>
+                                    tabs.map((tab, index) => {
+                                        return (
+                                            <DraggableTab
+                                                key={`tab-${tab.id}`}
+                                                id={`tab-${index}`}
+                                                index={index}
+                                                value={index}
+                                                label={
+                                                    <span
+                                                        style={{
+                                                            whiteSpace: 'nowrap',
+                                                        }}
                                                     >
-                                                        <CloseIcon />
-                                                    </TooltipIconButton>
-                                                </span>
-                                            }
-                                        />
-                                    );
-                                })
-                            }
-                            onDragEnd={handleDragEnd}
-                        />
-                        <TooltipIconButton
-                            tooltip={intl.formatMessage({
-                                id: 'DynamicSimulationAddTab',
-                            })}
-                            sx={styles.addButton}
-                            onClick={handleAddNewTab}
-                        >
-                            <AddIcon />
-                        </TooltipIconButton>
-                    </Box>
+                                                        {`${intl.formatMessage({
+                                                            id: 'DynamicSimulationResultTab',
+                                                        })} ${tab.id}`}
+                                                        <TooltipIconButton
+                                                            tooltip={intl.formatMessage({
+                                                                id: 'DynamicSimulationCloseTab',
+                                                            })}
+                                                            size="small"
+                                                            component="span"
+                                                            onClick={handleClose(index)}
+                                                        >
+                                                            <CloseIcon />
+                                                        </TooltipIconButton>
+                                                    </span>
+                                                }
+                                            />
+                                        );
+                                    })
+                                }
+                                onDragEnd={handleDragEnd}
+                            />
+                        </Grid>
+                        <Grid item padding={1}>
+                            <TooltipIconButton
+                                tooltip={intl.formatMessage({
+                                    id: 'DynamicSimulationAddTab',
+                                })}
+                                sx={styles.addButton}
+                                onClick={handleAddNewTab}
+                            >
+                                <AddIcon />
+                            </TooltipIconButton>
+                        </Grid>
+                    </Grid>
 
                     {/* tab contents */}
-                    <Box
+                    <Grid
                         sx={{
                             height: 'calc(100vh - 220px)', // TODO fix layout to use flexGrow : 1
                         }}
@@ -192,8 +197,8 @@ const DynamicSimulationResultTimeSeries = memo(function ({
                                 />
                             </VisibilityBox>
                         ))}
-                    </Box>
-                </Box>
+                    </Grid>
+                </Grid>
             </Overlay>
         </>
     );

--- a/src/components/results/dynamicsimulation/timeseries/dynamic-simulation-result-chart.tsx
+++ b/src/components/results/dynamicsimulation/timeseries/dynamic-simulation-result-chart.tsx
@@ -502,9 +502,9 @@ function DynamicSimulationResultChart({
                                         }}
                                     >
                                         <DynamicSimulationResultSeriesChart
-                                            key={`${plot.id}`}
-                                            id={`${plot.id}`}
-                                            groupId={`${groupId}`}
+                                            key={`chart-${plot.id}`}
+                                            id={plot.id}
+                                            groupId={groupId}
                                             index={index}
                                             selected={selectedIndex === index}
                                             onSelect={handleSelectIndex}

--- a/src/components/results/dynamicsimulation/timeseries/dynamic-simulation-result-series-chart.tsx
+++ b/src/components/results/dynamicsimulation/timeseries/dynamic-simulation-result-series-chart.tsx
@@ -9,7 +9,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import FitScreenSharpIcon from '@mui/icons-material/FitScreenSharp';
 import FullscreenExitSharpIcon from '@mui/icons-material/FullscreenExitSharp';
 import PlotlySeriesChart from '../plot/plotly-series-chart';
-import { Card, CardContent, CardHeader, Theme, ToggleButton, Tooltip, Typography } from '@mui/material';
+import { Card, CardContent, CardHeader, Theme, Typography } from '@mui/material';
 import { memo, useCallback, useState } from 'react';
 import TooltipIconButton from '../common/tooltip-icon-button';
 import { lighten } from '@mui/material/styles';
@@ -18,8 +18,8 @@ import { Series } from '../plot/plot-types';
 import { mergeSx } from '@gridsuite/commons-ui';
 
 const styles = {
-    plotScaleButton: (theme: Theme) => ({
-        marginRight: theme.spacing(2),
+    cardActionButton: (theme: Theme) => ({
+        marginRight: theme.spacing(0.5),
         border: 'none',
         borderRadius: '50%',
     }),
@@ -99,37 +99,45 @@ function DynamicSimulationResultSeriesChart({
                 }
                 action={
                     <>
-                        <ToggleButton
-                            sx={styles.plotScaleButton}
-                            size={'small'}
-                            value={'plotScale'}
-                            selected={plotScale}
-                            onChange={() => handlePlotScale(id)}
-                        >
-                            {plotScale ? (
-                                <Tooltip
-                                    title={intl.formatMessage({
-                                        id: 'DynamicSimulationPlotScaleDisable',
-                                    })}
-                                >
-                                    <FullscreenExitSharpIcon />
-                                </Tooltip>
-                            ) : (
-                                <Tooltip
-                                    title={intl.formatMessage({
-                                        id: 'DynamicSimulationPlotScaleEnable',
-                                    })}
-                                >
-                                    <FitScreenSharpIcon />
-                                </Tooltip>
-                            )}
-                        </ToggleButton>
+                        {plotScale ? (
+                            <TooltipIconButton
+                                key={'disabledScale'}
+                                sx={styles.cardActionButton}
+                                tooltip={intl.formatMessage({
+                                    id: 'DynamicSimulationPlotScaleDisable',
+                                })}
+                                onMouseDown={(event) => {
+                                    event.stopPropagation();
+                                    handlePlotScale(id);
+                                }}
+                            >
+                                <FullscreenExitSharpIcon />
+                            </TooltipIconButton>
+                        ) : (
+                            <TooltipIconButton
+                                key={'enableScale'}
+                                sx={styles.cardActionButton}
+                                tooltip={intl.formatMessage({
+                                    id: 'DynamicSimulationPlotScaleEnable',
+                                })}
+                                onMouseDown={(event) => {
+                                    event.stopPropagation();
+                                    handlePlotScale(id);
+                                }}
+                            >
+                                <FitScreenSharpIcon />
+                            </TooltipIconButton>
+                        )}
                         {!plotScale && (
                             <TooltipIconButton
+                                sx={styles.cardActionButton}
                                 tooltip={intl.formatMessage({
                                     id: 'DynamicSimulationCloseGraph',
                                 })}
-                                onClick={() => onClose(index)}
+                                onMouseDown={(event) => {
+                                    event.stopPropagation();
+                                    onClose(index);
+                                }}
                             >
                                 <CloseIcon />
                             </TooltipIconButton>


### PR DESCRIPTION
Corrections in this PR:

- Button Close and Zoom of each plot now handled by onMouseDown event instead of onClick due to the onClick event is not well captured from the usage of gridlayout library
- Using Grid system instead of Box for plot tabs header which is more compatible to our layout system 