### PR TITLE
[Dynamic Simulation] Correction for Sync of zoom between plots

### DIFF
--- a/src/components/results/dynamicsimulation/plot/plotly-series-chart.tsx
+++ b/src/components/results/dynamicsimulation/plot/plotly-series-chart.tsx
@@ -127,18 +127,15 @@ function PlotlySeriesChart({ id, groupId, leftSeries, rightSeries, sync }: Reado
                         xaxis: {
                             ...prev.xaxis,
                             range: [...(prev.xaxis.range ?? [])],
+                            autorange: false, // to force layout refresh with new range
                         },
                     };
 
                     newLayout.xaxis.range[0] = eventData['xaxis.range[0]'];
                     newLayout.xaxis.range[1] = eventData['xaxis.range[1]'];
-                    // force refresh Plot in mutable layout but not work???
-                    // newLayout.datarevision += 1;
 
                     return newLayout;
                 });
-                // force refresh Plot in mutable layout but not work???
-                // setRevision((prev) => prev + 1);
             }
         },
         [groupId, id]


### PR DESCRIPTION
**Observation:** a plot is not synced with a zoom action from another plot unless we manipulate (zoom, etc.) at least once on this plot.

**Reason:** the default layout for Xaxis is configured with field 'autorange' = true..

**Solution:** when sync from other plot, we force 'autorange' = false