### PR TITLE
[Dynamic Simulation] Correction for the lost of zoom when switching plot tabs

### DIFF
--- a/src/components/results/dynamicsimulation/common/gridlayout/responsive-grid-layout.tsx
+++ b/src/components/results/dynamicsimulation/common/gridlayout/responsive-grid-layout.tsx
@@ -10,20 +10,25 @@ import './react-grid-layout.custom.css';
 // TODO place these css at global or directly into useStyles for RGLResponsive
 import { Responsive as RGLResponsive, ResponsiveProps } from 'react-grid-layout';
 import AutoSizer from 'react-virtualized-auto-sizer';
+import { useEffect, useMemo } from 'react';
 
 export type ResponsiveGridLayoutProps = ResponsiveProps & {
     computeRowHeight: (height: number) => number;
 };
 
 function ResponsiveGridLayout({ computeRowHeight, ...otherProps }: Readonly<ResponsiveGridLayoutProps>) {
+    useEffect(() => {
+        return () => {
+            console.log(`XXX demonté ResponsiveGridLayout: `);
+        };
+    }, []);
+    const AutoSizerChildren = useMemo(() => {
+        return ({ width, height }: { width: number; height: number }) => (
+            <RGLResponsive width={width} rowHeight={computeRowHeight(height)} {...otherProps} />
+        );
+    }, [computeRowHeight, otherProps]);
     // use AutoSizer to make react-grid-layout Responsive component aware of width
-    return (
-        <AutoSizer>
-            {({ width, height }) => (
-                <RGLResponsive width={width} rowHeight={computeRowHeight(height)} {...otherProps} />
-            )}
-        </AutoSizer>
-    );
+    return <AutoSizer children={AutoSizerChildren} />;
 }
 
 export default ResponsiveGridLayout;

--- a/src/components/results/dynamicsimulation/common/visibility-box.tsx
+++ b/src/components/results/dynamicsimulation/common/visibility-box.tsx
@@ -11,7 +11,7 @@ const getStyle = (hidden: boolean) => {
     if (hidden) {
         return {
             visibility: 'hidden',
-            height: 0,
+            height: '1px',
         };
     }
     return {

--- a/src/components/results/dynamicsimulation/timeseries/dynamic-simulation-result-chart.tsx
+++ b/src/components/results/dynamicsimulation/timeseries/dynamic-simulation-result-chart.tsx
@@ -7,7 +7,7 @@
 
 import { Box, Grid, Paper, TextField, Theme, ToggleButton, Tooltip, Typography } from '@mui/material';
 import DynamicSimulationResultSeriesList from './dynamic-simulation-result-series-list';
-import { ChangeEvent, memo, useCallback, useMemo, useRef, useState } from 'react';
+import { ChangeEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import DynamicSimulationResultSeriesChart from './dynamic-simulation-result-series-chart';
 import VisibilityBox from '../common/visibility-box';
 import TooltipIconButton from '../common/tooltip-icon-button';
@@ -18,6 +18,7 @@ import { useIntl } from 'react-intl';
 import { MenuOpen } from '@mui/icons-material';
 import FitScreenSharpIcon from '@mui/icons-material/FitScreenSharp';
 import FullscreenExitSharpIcon from '@mui/icons-material/FullscreenExitSharp';
+import { Responsive as RGLResponsive, ResponsiveProps } from 'react-grid-layout';
 import ResponsiveGridLayout from '../common/gridlayout/responsive-grid-layout';
 import { lighten } from '@mui/material/styles';
 import { mergeSx, useDebounce } from '@gridsuite/commons-ui';
@@ -89,6 +90,11 @@ function getTimeseriesIndexes(metadata: TimeSeriesMetadata): number[] {
         : [];
 }
 
+function computeRowHeight(height: number) {
+    console.log(`XXX height ${height}`);
+    return height / 12;
+}
+
 export type DynamicSimulationResultChartProps = {
     groupId: string;
     timeseriesMetadatas?: SimpleTimeSeriesMetadata[];
@@ -103,6 +109,12 @@ function DynamicSimulationResultChart({
     loadTimeSeries,
 }: Readonly<DynamicSimulationResultChartProps>) {
     const intl = useIntl();
+    console.log('XXX rerender ', groupId);
+    useEffect(() => {
+        return () => {
+            console.log(`XXX démonté tab ${groupId}`);
+        };
+    }, [groupId]);
 
     const headers = useMemo(
         () => [
@@ -486,25 +498,27 @@ function DynamicSimulationResultChart({
                                     lg: gridLayout.items,
                                 }}
                                 isBounded={true}
-                                computeRowHeight={(height) => height / 12}
+                                computeRowHeight={computeRowHeight}
+                                // rowHeight={100}
+                                // width={1000}
                                 onBreakpointChange={handleBreakpointChange}
                                 onLayoutChange={handleLayoutChange}
                             >
                                 {plots.map((plot, index) => (
-                                    <Box
+                                    <div
                                         key={plot.id}
-                                        sx={{
-                                            display: plotIdScale
-                                                ? plotIdScale !== plot.id
-                                                    ? 'none'
-                                                    : 'block'
-                                                : 'block',
-                                        }}
+                                        // sx={{
+                                        //     display: plotIdScale
+                                        //         ? plotIdScale !== plot.id
+                                        //             ? 'none'
+                                        //             : 'block'
+                                        //         : 'block',
+                                        // }}
                                     >
                                         <DynamicSimulationResultSeriesChart
-                                            key={`${plot.id}`}
-                                            id={`${plot.id}`}
-                                            groupId={`${groupId}`}
+                                            key={plot.id}
+                                            id={plot.id}
+                                            groupId={groupId}
                                             index={index}
                                             selected={selectedIndex === index}
                                             onSelect={handleSelectIndex}
@@ -514,7 +528,7 @@ function DynamicSimulationResultChart({
                                             sync={sync}
                                             onPlotScale={handlePlotScale}
                                         />
-                                    </Box>
+                                    </div>
                                 ))}
                             </ResponsiveGridLayout>
                         </Box>

--- a/src/components/results/dynamicsimulation/timeseries/dynamic-simulation-result-series-chart.tsx
+++ b/src/components/results/dynamicsimulation/timeseries/dynamic-simulation-result-series-chart.tsx
@@ -10,7 +10,7 @@ import FitScreenSharpIcon from '@mui/icons-material/FitScreenSharp';
 import FullscreenExitSharpIcon from '@mui/icons-material/FullscreenExitSharp';
 import PlotlySeriesChart from '../plot/plotly-series-chart';
 import { Card, CardContent, CardHeader, Theme, ToggleButton, Tooltip, Typography } from '@mui/material';
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import TooltipIconButton from '../common/tooltip-icon-button';
 import { lighten } from '@mui/material/styles';
 import { useIntl } from 'react-intl';
@@ -70,6 +70,12 @@ function DynamicSimulationResultSeriesChart({
     onPlotScale = () => {},
 }: Readonly<DynamicSimulationResultSeriesChartProps>) {
     const intl = useIntl();
+    useEffect(() => {
+        console.log(`XXX remount DynamicSimulationResultSeriesChart ${id} ${groupId}`);
+        return () => {
+            console.log(`XXX démonté DynamicSimulationResultSeriesChart ${id} ${groupId}`);
+        };
+    }, [id, groupId]);
 
     // button options switch scale plot / restore plot
     const [plotScale, setPlotScale] = useState<boolean>(false);


### PR DESCRIPTION
**Observation:** when zoom action is done in some plots of a tab, then switching to another tab.. when backing to the first one, zoom is lost

**Reason:** plots in the first tab are unmounted when switching to another tab..

**Solution:** make plots not unmounted