### PR TITLE
[Dynamic Simulation] Prevent plots unmounted when switching tabs

### DIFF
--- a/src/components/results/dynamicsimulation/common/gridlayout/responsive-grid-layout.tsx
+++ b/src/components/results/dynamicsimulation/common/gridlayout/responsive-grid-layout.tsx
@@ -10,18 +10,44 @@ import './react-grid-layout.custom.css';
 // TODO place these css at global or directly into useStyles for RGLResponsive
 import { Responsive as RGLResponsive, ResponsiveProps } from 'react-grid-layout';
 import AutoSizer from 'react-virtualized-auto-sizer';
+import { MutableRefObject, useRef } from 'react';
+
+function getDimensions(
+    width: number,
+    height: number,
+    prevDimensionRef: MutableRefObject<{
+        width: number;
+        height: number;
+    }>
+) {
+    // when a parent component is hidden, width and height computed by AutoSizer may be not valid, e.g. negative or zero
+    // need to reuse the previous valid dimensions
+    const newWidth = width > 0 ? width : prevDimensionRef.current.width;
+    const newHeight = height > 0 ? height : prevDimensionRef.current.height;
+
+    // update previous with valid dimensions
+    if (newWidth !== prevDimensionRef.current.width) {
+        prevDimensionRef.current.width = newWidth;
+    }
+    if (newHeight !== prevDimensionRef.current.height) {
+        prevDimensionRef.current.height = newHeight;
+    }
+    return { newWidth, newHeight };
+}
 
 export type ResponsiveGridLayoutProps = ResponsiveProps & {
     computeRowHeight: (height: number) => number;
 };
 
 function ResponsiveGridLayout({ computeRowHeight, ...otherProps }: Readonly<ResponsiveGridLayoutProps>) {
+    const prevDimensionsRef = useRef({ width: 0, height: 0 });
     // use AutoSizer to make react-grid-layout Responsive component aware of width
     return (
-        <AutoSizer>
-            {({ width, height }) => (
-                <RGLResponsive width={width} rowHeight={computeRowHeight(height)} {...otherProps} />
-            )}
+        <AutoSizer doNotBailOutOnEmptyChildren /* to prevent unmount children when computed dimensions are zero */>
+            {({ width, height }) => {
+                const { newWidth, newHeight } = getDimensions(width, height, prevDimensionsRef);
+                return <RGLResponsive width={newWidth} rowHeight={computeRowHeight(newHeight)} {...otherProps} />;
+            }}
         </AutoSizer>
     );
 }

--- a/src/components/results/dynamicsimulation/common/visibility-box.tsx
+++ b/src/components/results/dynamicsimulation/common/visibility-box.tsx
@@ -10,13 +10,13 @@ import { Box, BoxProps } from '@mui/material';
 const getStyle = (hidden: boolean) => {
     if (hidden) {
         return {
-            visibility: 'hidden',
-            height: 0,
+            display: 'none',
         };
     }
     return {
-        visibility: 'visible',
-        height: 'inherit',
+        display: 'flex',
+        height: '100%',
+        width: '100%',
     };
 };
 


### PR DESCRIPTION
It seems a regression due to the migration of library autosizer

**Observation:** when we have two tabs of plots, and zooming on a plot of the first tab. Switching to the second tab then back to the first => plot is reset and previous zooming is lost.

**Reason:** when AutoSizer computes width and height from a hidden parent component, width and height may be zero and AutoSizer ignore rendering children (regression from new version autosizer)

**Solution:** fortunatly, the recent new version of AutoSizer provides a props to override this behaviour, i.e. doNotBailOutOnEmptyChildren

**Enhancement:** when providing width and height for the GridLayout, we provide a filter to take only valid computed dimensions, otherwise, the previous valid dimensions are taken into account.. This is usefull when a tab content is waked up from display=hidden to display=flex and we do not see a flash that GridLayout reorganizes plots 