### PR TITLE
Fix Diagrams load from session storage

### DIFF
--- a/src/components/diagrams/diagram-grid-layout.tsx
+++ b/src/components/diagrams/diagram-grid-layout.tsx
@@ -102,7 +102,7 @@ function DiagramGridLayout({ studyUuid, showInSpreadsheet, visible }: Readonly<D
         });
     };
     const { diagrams, removeDiagram, createDiagram } = useDiagramModel({
-        diagramTypes: enableDeveloperMode ? diagramTypes : [],
+        diagramTypes: diagramTypes,
         onAddDiagram,
     });
 

--- a/src/components/diagrams/hooks/use-diagram-session-storage.ts
+++ b/src/components/diagrams/hooks/use-diagram-session-storage.ts
@@ -9,7 +9,7 @@ import { UUID } from 'crypto';
 import { Diagram, DiagramParams } from '../diagram.type';
 import { useSelector } from 'react-redux';
 import { AppState } from 'redux/reducer';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { loadDiagramsFromSessionStorage, syncDiagramsWithSessionStorage } from 'redux/session-storage/diagram-state';
 
 const keyToKeepInSessionStorage = [
@@ -29,16 +29,14 @@ type useDiagramSessionStorageProps = {
 
 export const useDiagramSessionStorage = ({ diagrams, onLoadFromSessionStorage }: useDiagramSessionStorageProps) => {
     const studyUuid = useSelector((state: AppState) => state.studyUuid);
-
-    // at mount
-    useEffect(() => {
+    useState<DiagramParams[]>(() => {
         if (!studyUuid) {
-            return;
+            return [];
         }
         const diagrams: DiagramParams[] = loadDiagramsFromSessionStorage(studyUuid);
         diagrams.forEach((diagramParams) => onLoadFromSessionStorage(diagramParams));
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        return diagrams;
+    });
 
     // at update
     useEffect(() => {

--- a/src/components/map-viewer.jsx
+++ b/src/components/map-viewer.jsx
@@ -27,6 +27,8 @@ import { StudyView } from './utils/utils';
 import { DiagramType } from './diagrams/diagram.type';
 import WaitingLoader from './utils/waiting-loader';
 import DiagramGridLayout from './diagrams/diagram-grid-layout';
+import { useParameterState } from './dialogs/parameters/use-parameters-state';
+import { PARAM_DEVELOPER_MODE } from 'utils/config-params';
 
 const styles = {
     map: {
@@ -142,6 +144,7 @@ const MapViewer = ({
 
     const networkVisuParams = useSelector((state) => state.networkVisualizationsParameters);
     const studyDisplayMode = useSelector((state) => state.studyDisplayMode);
+    const enableDeveloperMode = useParameterState(PARAM_DEVELOPER_MODE);
     const previousStudyDisplayMode = useRef(undefined);
     const isNetworkModificationTreeModelUpToDate = useSelector((state) => state.isNetworkModificationTreeModelUpToDate);
 
@@ -281,14 +284,16 @@ const MapViewer = ({
                         flexBasis: studyDisplayMode === StudyDisplayMode.DIAGRAM_GRID_LAYOUT_AND_TREE ? '50%' : '100%',
                     }}
                 >
-                    <DiagramGridLayout
-                        studyUuid={studyUuid}
-                        visible={
-                            studyDisplayMode === StudyDisplayMode.DIAGRAM_GRID_LAYOUT ||
-                            studyDisplayMode === StudyDisplayMode.DIAGRAM_GRID_LAYOUT_AND_TREE
-                        }
-                        showInSpreadsheet={showInSpreadsheet}
-                    ></DiagramGridLayout>
+                    {enableDeveloperMode && (
+                        <DiagramGridLayout
+                            studyUuid={studyUuid}
+                            visible={
+                                studyDisplayMode === StudyDisplayMode.DIAGRAM_GRID_LAYOUT ||
+                                studyDisplayMode === StudyDisplayMode.DIAGRAM_GRID_LAYOUT_AND_TREE
+                            }
+                            showInSpreadsheet={showInSpreadsheet}
+                        />
+                    )}
                 </Box>
                 {/* Map */}
                 <Box


### PR DESCRIPTION
fix(MapViewer): do not render `DiagramGridLayout` at all if not in developer mode to avoid session storage load/save desynchro