### PR TITLE
Remove global warning panel on update dialogbox and invalid node.

### DIFF
--- a/src/components/dialogs/commons/modification-dialog-content.tsx
+++ b/src/components/dialogs/commons/modification-dialog-content.tsx
@@ -5,25 +5,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Grid, Dialog, DialogTitle, DialogContent, DialogActions, LinearProgress, Alert } from '@mui/material';
+import { Grid, Dialog, DialogTitle, DialogContent, DialogActions, LinearProgress } from '@mui/material';
 import { useButtonWithTooltip } from '../../utils/inputs/input-hooks';
 import FindInPageIcon from '@mui/icons-material/FindInPage';
 import AutoStoriesOutlinedIcon from '@mui/icons-material/AutoStoriesOutlined';
-import { useSelector } from 'react-redux';
-import { BUILD_STATUS } from '../../network/constants';
-import { Theme } from '@mui/material/styles';
 import React, { ReactNode } from 'react';
 import { UseFormSearchCopy } from './use-form-search-copy';
 import { FormattedMessage } from 'react-intl';
 import { CancelButton } from '@gridsuite/commons-ui';
-import { AppState } from '../../../redux/reducer';
 import { DialogProps } from '@mui/material/Dialog/Dialog';
-
-const styles = {
-    warningMessage: (theme: Theme) => ({
-        backgroundColor: theme.formFiller.background,
-    }),
-};
 
 /**
  * Common parts for the Modification Dialog
@@ -43,7 +33,6 @@ export type ModificationDialogContentProps = Omit<DialogProps, 'onClose' | 'aria
     titleId: string;
     onOpenCatalogDialog?: () => void;
     searchCopy?: UseFormSearchCopy;
-    showNodeNotBuiltWarning?: boolean;
     submitButton: ReactNode;
     subtitle?: ReactNode;
 };
@@ -54,7 +43,6 @@ export function ModificationDialogContent({
     titleId,
     onOpenCatalogDialog,
     searchCopy,
-    showNodeNotBuiltWarning = false,
     submitButton,
     subtitle,
     ...dialogProps
@@ -64,8 +52,6 @@ export function ModificationDialogContent({
         handleClick: onOpenCatalogDialog ?? (() => {}),
         icon: <AutoStoriesOutlinedIcon />,
     });
-    const currentNode = useSelector((state: AppState) => state.currentTreeNode);
-    const isNodeNotBuilt = currentNode?.data?.globalBuildStatus === BUILD_STATUS.NOT_BUILT;
     const copyEquipmentButton = useButtonWithTooltip({
         label: 'CopyFromExisting',
         handleClick: searchCopy?.handleOpenSearchDialog ?? (() => {}),
@@ -93,13 +79,6 @@ export function ModificationDialogContent({
                     </Grid>
 
                     <Grid item xs={6} container spacing={2} justifyContent={'right'}>
-                        {showNodeNotBuiltWarning && isNodeNotBuilt && (
-                            <Grid item xs={10}>
-                                <Alert severity={'warning'} sx={styles.warningMessage}>
-                                    <FormattedMessage id="ModifyNodeNotBuiltWarningMsg" />
-                                </Alert>
-                            </Grid>
-                        )}
                         {onOpenCatalogDialog && (
                             <Grid item xs={1}>
                                 {catalogButton}

--- a/src/components/dialogs/dynamicsimulation/event/dynamic-simulation-event-dialog.tsx
+++ b/src/components/dialogs/dynamicsimulation/event/dynamic-simulation-event-dialog.tsx
@@ -188,7 +188,6 @@ export const DynamicSimulationEventDialog = (props: DynamicSimulationEventDialog
                 titleId={title}
                 open={open}
                 keepMounted={true}
-                showNodeNotBuiltWarning={!!equipmentId}
                 isDataFetching={dataFetchStatus === FetchStatus.RUNNING}
                 {...dialogProps}
             >

--- a/src/components/dialogs/network-modifications/battery/modification/battery-modification-dialog.tsx
+++ b/src/components/dialogs/network-modifications/battery/modification/battery-modification-dialog.tsx
@@ -337,7 +337,6 @@ export default function BatteryModificationDialog({
                 titleId="ModifyBattery"
                 open={open}
                 keepMounted={true}
-                showNodeNotBuiltWarning={selectedId != null}
                 isDataFetching={
                     isUpdate && (editDataFetchStatus === FetchStatus.RUNNING || dataFetchStatus === FetchStatus.RUNNING)
                 }

--- a/src/components/dialogs/network-modifications/coupling-device/modification/create-coupling-device-dialog.tsx
+++ b/src/components/dialogs/network-modifications/coupling-device/modification/create-coupling-device-dialog.tsx
@@ -172,7 +172,6 @@ export default function CreateCouplingDeviceDialog({
                 open={open}
                 titleId={'CREATE_COUPLING_DEVICE'}
                 keepMounted={true}
-                showNodeNotBuiltWarning={selectedId != null}
                 isDataFetching={
                     isUpdate && (editDataFetchStatus === FetchStatus.RUNNING || dataFetchStatus === FetchStatus.RUNNING)
                 }

--- a/src/components/dialogs/network-modifications/generator/modification/generator-modification-dialog.tsx
+++ b/src/components/dialogs/network-modifications/generator/modification/generator-modification-dialog.tsx
@@ -413,7 +413,6 @@ export default function GeneratorModificationDialog({
                 titleId="ModifyGenerator"
                 open={open}
                 keepMounted={true}
-                showNodeNotBuiltWarning={selectedId != null}
                 isDataFetching={
                     isUpdate && (editDataFetchStatus === FetchStatus.RUNNING || dataFetchStatus === FetchStatus.RUNNING)
                 }

--- a/src/components/dialogs/network-modifications/hvdc-line/lcc/modification/lcc-modification-dialog.tsx
+++ b/src/components/dialogs/network-modifications/hvdc-line/lcc/modification/lcc-modification-dialog.tsx
@@ -264,7 +264,6 @@ export const LccModificationDialog = ({
                 }}
                 open={open}
                 keepMounted={true}
-                showNodeNotBuiltWarning={equipmentId != null}
                 isDataFetching={
                     isUpdate && (editDataFetchStatus === FetchStatus.RUNNING || dataFetchStatus === FetchStatus.RUNNING)
                 }

--- a/src/components/dialogs/network-modifications/load/modification/load-modification-dialog.tsx
+++ b/src/components/dialogs/network-modifications/load/modification/load-modification-dialog.tsx
@@ -289,7 +289,6 @@ export default function LoadModificationDialog({
                 titleId="ModifyLoad"
                 open={open}
                 keepMounted={true}
-                showNodeNotBuiltWarning={selectedId != null}
                 isDataFetching={
                     isUpdate && (editDataFetchStatus === FetchStatus.RUNNING || dataFetchStatus === FetchStatus.RUNNING)
                 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -501,7 +501,6 @@
     "showReport": "Show logs",
     "loadingReport": "Loading logs in progress...",
 
-    "ModifyNodeNotBuiltWarningMsg": "The values are those of the previous built node in the current branch",
     "Optional": " (optional)",
     "loadingOptions": "Loading...",
     "buildNode": "Build node",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -500,8 +500,6 @@
     "showReport": "Afficher logs",
     "loadingReport": "Chargement des logs en cours...",
 
-    "ModifyNodeNotBuiltWarningMsg": "Les valeurs sont celles du précédent nœud réalisé dans la branche courante",
-
     "Optional": " (optionnel)",
     "loadingOptions": "Chargement...",
     "buildNode": "Réaliser le nœud",


### PR DESCRIPTION
Remove global warning panel on modification dialogbox when the current node is invalid.