### PR TITLE
Fix Diagram Grid Layout inconsistent layout at card removal

### DIFF
--- a/src/components/diagrams/diagram-grid-layout.tsx
+++ b/src/components/diagrams/diagram-grid-layout.tsx
@@ -136,14 +136,7 @@ function DiagramGridLayout({ studyUuid, showInSpreadsheet, visible }: Readonly<D
     };
 
     const removeLayoutItem = (cardUuid: UUID) => {
-        setLayouts((old_layouts) => {
-            const oldLayoutsEntries = Object.entries(old_layouts);
-            if (oldLayoutsEntries.at(0)?.[1].length === 2) {
-                return initialLayouts; // Reset to initial layouts if no diagrams left
-            }
-            const newLayoutsEntries = removeInLayoutEntries(oldLayoutsEntries, cardUuid);
-            return Object.fromEntries(newLayoutsEntries);
-        });
+        setLayouts((old_layouts) => Object.fromEntries(removeInLayoutEntries(Object.entries(old_layouts), cardUuid)));
     };
 
     const stopDiagramBlinking = useCallback((diagramUuid: UUID) => {

--- a/src/components/diagrams/diagram-grid-layout.tsx
+++ b/src/components/diagrams/diagram-grid-layout.tsx
@@ -138,7 +138,7 @@ function DiagramGridLayout({ studyUuid, showInSpreadsheet, visible }: Readonly<D
     const removeLayoutItem = (cardUuid: UUID) => {
         setLayouts((old_layouts) => {
             const oldLayoutsEntries = Object.entries(old_layouts);
-            if (oldLayoutsEntries.pop()?.[1].length === 2) {
+            if (oldLayoutsEntries.at(0)?.[1].length === 2) {
                 return initialLayouts; // Reset to initial layouts if no diagrams left
             }
             const newLayoutsEntries = removeInLayoutEntries(oldLayoutsEntries, cardUuid);


### PR DESCRIPTION
fix(DGL): Do not pop because it removes the entry from the original array.

Just check the size without modification of the array.