### PR TITLE
Feat DiagramGridLayout: Manage Map Card save in layout and removal

### DIFF
--- a/src/components/diagrams/diagram-grid-layout.types.ts
+++ b/src/components/diagrams/diagram-grid-layout.types.ts
@@ -6,6 +6,7 @@
  */
 
 import { DiagramParams, DiagramParamsDto } from 'components/diagrams/diagram.type';
+import { UUID } from 'crypto';
 import { Layout } from 'react-grid-layout';
 
 export type DiagramLayoutParam = DiagramParams & {
@@ -16,7 +17,12 @@ export interface DiagramGridLayout {
     diagramLayouts: DiagramLayoutParam[];
 }
 
-export type DiagramLayoutDto = DiagramParamsDto & {
+type MapDTO = {
+    diagramUuid: UUID;
+    type: 'map';
+};
+
+export type DiagramLayoutDto = (DiagramParamsDto | MapDTO) & {
     diagramPositions: Record<string, Pick<Layout, 'w' | 'h' | 'x' | 'y'>>;
 };
 

--- a/src/components/diagrams/hooks/use-save-diagram-layout.ts
+++ b/src/components/diagrams/hooks/use-save-diagram-layout.ts
@@ -15,6 +15,7 @@ import { DiagramGridLayoutDto, DiagramLayoutDto } from 'components/diagrams/diag
 import { MAX_INT32 } from 'services/utils';
 import { saveDiagramGridLayout } from 'services/study/study-config';
 import { useSnackMessage } from '@gridsuite/commons-ui';
+import { v4 } from 'uuid';
 
 interface UseSaveDiagramLayoutProps {
     layouts: Layouts;
@@ -62,6 +63,14 @@ const frontendToBackendDiagramGridLayout = (diagram: DiagramGridLayoutConfig): D
             diagramLayouts.push(transformedParam);
         }
     });
+
+    // get the map from gridLayoutById
+    const transformedMapDTO: DiagramLayoutDto = {
+        diagramUuid: v4() as UUID,
+        type: 'map',
+        diagramPositions: gridLayoutById['MapCard'],
+    };
+    diagramLayouts.push(transformedMapDTO);
 
     return {
         diagramLayouts: diagramLayouts,

--- a/src/hooks/use-diagram-grid-layout.ts
+++ b/src/hooks/use-diagram-grid-layout.ts
@@ -42,14 +42,14 @@ const decodeInfinity = (value: number) => {
 const backendToFrontendGridLayout = (diagramGridLayout: DiagramGridLayoutDto): DiagramGridLayoutConfig => {
     const gridLayoutResult: Layouts = {};
 
-    for (const { diagramUuid, diagramPositions } of diagramGridLayout.diagramLayouts) {
+    for (const { diagramUuid, type, diagramPositions } of diagramGridLayout.diagramLayouts) {
         for (const [layoutKey, layoutValues] of Object.entries(diagramPositions)) {
             if (!gridLayoutResult[layoutKey]) {
                 gridLayoutResult[layoutKey] = [];
             }
             gridLayoutResult[layoutKey].push({
                 ...layoutValues,
-                i: diagramUuid,
+                i: type === 'map' ? 'MapCard' : diagramUuid,
                 x: decodeInfinity(layoutValues.x),
                 y: decodeInfinity(layoutValues.y),
             });
@@ -58,22 +58,24 @@ const backendToFrontendGridLayout = (diagramGridLayout: DiagramGridLayoutDto): D
 
     return {
         gridLayouts: gridLayoutResult,
-        params: diagramGridLayout.diagramLayouts.map((layout) => {
-            if (layout.type === DiagramType.NETWORK_AREA_DIAGRAM) {
-                return {
-                    type: layout.type,
-                    diagramUuid: layout.diagramUuid,
-                    nadConfigUuid: layout.originalNadConfigUuid,
-                    initializationNadConfigUuid: layout.currentNadConfigUuid,
-                    filterUuid: layout.filterUuid,
-                    name: layout.name,
-                    voltageLevelIds: [],
-                    voltageLevelToExpandIds: [],
-                    voltageLevelToOmitIds: [],
-                    positions: [],
-                };
-            }
-            return layout;
-        }),
+        params: diagramGridLayout.diagramLayouts
+            .filter((layout) => layout.type !== 'map')
+            .map((layout) => {
+                if (layout.type === DiagramType.NETWORK_AREA_DIAGRAM) {
+                    return {
+                        type: layout.type,
+                        diagramUuid: layout.diagramUuid,
+                        nadConfigUuid: layout.originalNadConfigUuid,
+                        initializationNadConfigUuid: layout.currentNadConfigUuid,
+                        filterUuid: layout.filterUuid,
+                        name: layout.name,
+                        voltageLevelIds: [],
+                        voltageLevelToExpandIds: [],
+                        voltageLevelToOmitIds: [],
+                        positions: [],
+                    };
+                }
+                return layout;
+            }),
     };
 };


### PR DESCRIPTION
Adapt `frontendToBackendDiagramGridLayout` and `backendToFrontendGridLayout` to manage the Map Card