### PR TITLE
Add callback to populate unset regulation attributes with previous values

### DIFF
--- a/src/components/dialogs/network-modifications/two-windings-transformer/tap-changer-pane/ratio-tap-changer-pane/ratio-tap-changer-pane-utils.js
+++ b/src/components/dialogs/network-modifications/two-windings-transformer/tap-changer-pane/ratio-tap-changer-pane/ratio-tap-changer-pane-utils.js
@@ -285,19 +285,27 @@ export const getInitialTwtRatioRegulationModeId = (twt) => {
     return computedRegulationMode?.id || null;
 };
 
+export const getComputedRegulationModeId = (twt) => {
+    return getComputedRegulationMode(twt)?.id || null;
+};
+
 export const getComputedPreviousRatioRegulationType = (previousValues) => {
     const previousRegulationType = getComputedRegulationType(previousValues);
     return previousRegulationType?.id || null;
 };
 
-export const getComputedTapSideId = (twt) => {
+export const getComputedTapSide = (twt) => {
     const ratioTapChangerValues = twt?.ratioTapChanger;
     if (!ratioTapChangerValues || !twt) {
         return null;
     }
     if (ratioTapChangerValues?.regulatingTerminalConnectableId === twt?.id) {
-        return ratioTapChangerValues?.regulatingTerminalVlId === twt?.voltageLevelId1 ? SIDE.SIDE1.id : SIDE.SIDE2.id;
+        return ratioTapChangerValues?.regulatingTerminalVlId === twt?.voltageLevelId1 ? SIDE.SIDE1 : SIDE.SIDE2;
     } else {
         return null;
     }
+};
+
+export const getComputedTapSideId = (twt) => {
+    return getComputedTapSide(twt)?.id || null;
 };

--- a/src/components/utils/rhf-inputs/boolean-nullable-input.tsx
+++ b/src/components/utils/rhf-inputs/boolean-nullable-input.tsx
@@ -19,6 +19,7 @@ interface CheckboxNullableInputProps {
     formProps?: CheckboxProps;
     previousValue?: string;
     nullDisabled?: boolean;
+    onChange?: (value: boolean | null) => void;
     style?: { color: string };
 }
 
@@ -29,24 +30,28 @@ const CheckboxNullableInput = ({
     formProps,
     previousValue,
     nullDisabled,
+    onChange,
     style,
 }: Readonly<CheckboxNullableInputProps>) => {
     const {
-        field: { onChange, value },
+        field: { onChange: rhfOnChange, value },
     } = useController({ name });
 
     const intl = useIntl();
     const { isNodeBuilt, isUpdate } = useCustomFormContext();
 
     const handleChangeValue = useCallback(() => {
+        let newValue;
         if (value) {
-            onChange(null);
+            newValue = null;
         } else if (value === null) {
-            onChange(false);
+            newValue = false;
         } else {
-            onChange(true);
+            newValue = true;
         }
-    }, [onChange, value]);
+        rhfOnChange(newValue);
+        onChange?.(newValue);
+    }, [rhfOnChange, onChange, value]);
 
     // Get the current label based on value
     const currentLabel = typeof label === 'function' ? label(value) : label;


### PR DESCRIPTION
When the user enable onload we autofill the regulation attributes with the previous values of the equipment