### PR TITLE
better limit name schema validation

### DIFF
--- a/src/components/dialogs/limits/temporary-limits-table.tsx
+++ b/src/components/dialogs/limits/temporary-limits-table.tsx
@@ -151,7 +151,11 @@ function TemporaryLimitsTable({
     );
 
     const renderTableRow = (rowId: string, index: number) => (
-        <TableRow onMouseEnter={() => setHoveredRowIndex(index)} onMouseLeave={() => setHoveredRowIndex(-1)}>
+        <TableRow
+            key={'row' + rowId}
+            onMouseEnter={() => setHoveredRowIndex(index)}
+            onMouseLeave={() => setHoveredRowIndex(-1)}
+        >
             {columnsDefinition.map((column) => renderTableCell(rowId, index, column))}
             <TableCell key={rowId + 'delete'}>
                 <IconButton


### PR DESCRIPTION
1. Adds a missing key
2. simplify limit name validation and prevent an error when a user delete a limit and recreate one with the same name -> the deleted limit is still there and counted as a doublon of limits with the same name
3. I removed some checks which are obsolete

I am not sure that this is a right thing to put all those field to UNDEFINED in the limit types. -> should be checked