### PR TITLE
Fix sonar issue Prefer node:crypto over crypto (continuation)

### DIFF
--- a/src/components/dialogs/network-modifications/voltage-level/move-feeder-bays/move-voltage-level-feeder-bays-form.tsx
+++ b/src/components/dialogs/network-modifications/voltage-level/move-feeder-bays/move-voltage-level-feeder-bays-form.tsx
@@ -26,7 +26,7 @@ import FeederBayDirectionCellRenderer from './feeder-bay-direction-cell-render';
 import GridItem from '../../../commons/grid-item';
 import Button from '@mui/material/Button';
 import { InfoOutlined } from '@mui/icons-material';
-import { UUID } from 'crypto';
+import type { UUID } from 'node:crypto';
 import { FeederBaysFormInfos, FeederBaysInfos } from './move-voltage-level-feeder-bays.type';
 import PositionDiagramPane from '../../../../grid-layout/cards/diagrams/singleLineDiagram/positionDiagram/position-diagram-pane';
 import SeparatorCellRenderer from '../topology-modification/separator-cell-renderer';

--- a/src/components/graph/menus/root-network/root-network-modification-results.tsx
+++ b/src/components/graph/menus/root-network/root-network-modification-results.tsx
@@ -9,7 +9,7 @@ import { useModificationLabelComputer } from '@gridsuite/commons-ui';
 import { useCallback } from 'react';
 import { Modification } from './root-network.types';
 import { Box, Theme, Typography } from '@mui/material';
-import { UUID } from 'crypto';
+import type { UUID } from 'node:crypto';
 import { AppState } from 'redux/reducer';
 import { useDispatch, useSelector } from 'react-redux';
 import { setHighlightModification, setModificationsDrawerOpen } from 'redux/actions';

--- a/src/components/grid-layout/dialog/map-dialog.tsx
+++ b/src/components/grid-layout/dialog/map-dialog.tsx
@@ -6,7 +6,7 @@
  */
 import { Dialog, Fab, Theme } from '@mui/material';
 import { useCallback, useRef } from 'react';
-import { UUID } from 'crypto';
+import type { UUID } from 'node:crypto';
 import { EquipmentType, LineFlowMode, NetworkVisualizationParameters, useStateBoolean } from '@gridsuite/commons-ui';
 import { useDispatch, useSelector } from 'react-redux';
 import { AppState } from 'redux/reducer';

--- a/src/components/results/loadflow/use-load-flow-result-column-actions.ts
+++ b/src/components/results/loadflow/use-load-flow-result-column-actions.ts
@@ -10,7 +10,7 @@ import { OverloadedEquipment } from './load-flow-result.type';
 import { ColDef } from 'ag-grid-community';
 import { fetchVoltageLevelIdForLineOrTransformerBySide } from '../../../services/study/network-map';
 import { BranchSide } from '../../utils/constants';
-import { UUID } from 'crypto';
+import type { UUID } from 'node:crypto';
 import { useSnackMessage } from '@gridsuite/commons-ui';
 import { useIntl } from 'react-intl';
 


### PR DESCRIPTION
refactor(crypto): Node.js built-in modules should be imported using the "node:" protocol typescript:S7772