### PR TITLE
Fix double update column call when updating column

### DIFF
--- a/src/components/custom-aggrid/custom-aggrid-filters/hooks/use-custom-aggrid-column-filter.ts
+++ b/src/components/custom-aggrid/custom-aggrid-filters/hooks/use-custom-aggrid-column-filter.ts
@@ -19,11 +19,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { snackWithFallback, useSnackMessage } from '@gridsuite/commons-ui';
 import { AppState } from '../../../../redux/reducer.type';
 import { getColumnFiltersFromState } from '../../../../redux/selectors/filter-selectors';
-import { persistSpreadsheetColumnFilters } from '../../../spreadsheet-view/columns/utils/persist-spreadsheet-column-filters';
+import { persistSpreadsheetColumnFilter } from '../../../spreadsheet-view/columns/utils/persist-spreadsheet-column-filter';
 import type { UUID } from 'node:crypto';
 import { updateColumnFiltersAction } from '../../../../redux/actions';
 
-import { persistComputationColumnFilters } from '../../../results/common/column-filter/persist-computation-column-filters';
+import { persistComputationColumnFilter } from '../../../results/common/column-filter/persist-computation-column-filter';
 
 const removeElementFromArrayWithFieldValue = (filtersArrayToRemoveFieldValueFrom: FilterConfig[], field: string) => {
     return filtersArrayToRemoveFieldValueFrom.filter((f) => f.column !== field);
@@ -99,6 +99,7 @@ export const useCustomAggridColumnFilter = (
                 updatedFilters = changeValueFromArrayWithFieldValue(filters, colId, newFilter);
             }
 
+            const colFilter = updatedFilters.find((f) => f.column === colId);
             const onError = (error: unknown) => snackWithFallback(snackError, error);
 
             // Data flow for logs table is: update redux state -> useEffect -> update hook state
@@ -107,9 +108,9 @@ export const useCustomAggridColumnFilter = (
             }
             // Data flow for spreadsheet / computation tables is: update backend database -> notification -> update redux state -> useEffect -> update hook state
             else if (type === TableType.Spreadsheet) {
-                persistSpreadsheetColumnFilters(studyUuid, tab as UUID, colDef, updatedFilters, onError);
+                persistSpreadsheetColumnFilter(studyUuid, tab as UUID, colDef, colFilter, onError);
             } else {
-                persistComputationColumnFilters(studyUuid, type, tab, colId, updatedFilters, onError);
+                persistComputationColumnFilter(studyUuid, type, tab, colId, colFilter, onError);
             }
         },
         [studyUuid, colId, type, filters, snackError, tab, dispatch, colDef]

--- a/src/components/results/common/column-filter/persist-computation-column-filter.ts
+++ b/src/components/results/common/column-filter/persist-computation-column-filter.ts
@@ -13,17 +13,17 @@ export const persistComputationColumnFilter = (
     computationType: TableType,
     computationSubType: string,
     colId: string,
-    filter: FilterConfig | undefined,
+    colFilter: FilterConfig | undefined,
     onError: (error: unknown) => void
 ) => {
     const columnFilterInfos = {
         columnId: colId,
-        columnFilterInfos: filter
+        columnFilterInfos: colFilter
             ? {
-                  filterDataType: filter?.dataType,
-                  filterType: filter?.type,
-                  filterValue: JSON.stringify(filter?.value),
-                  filterTolerance: filter?.tolerance,
+                  filterDataType: colFilter?.dataType,
+                  filterType: colFilter?.type,
+                  filterValue: JSON.stringify(colFilter?.value),
+                  filterTolerance: colFilter?.tolerance,
               }
             : null,
     };

--- a/src/components/results/common/column-filter/persist-computation-column-filter.ts
+++ b/src/components/results/common/column-filter/persist-computation-column-filter.ts
@@ -8,15 +8,14 @@ import { UUID } from 'node:crypto';
 import { FilterConfig, TableType } from '../../../../types/custom-aggrid-types';
 import { updateComputationResultFiltersColumn } from '../../../../services/study/study-config';
 
-export const persistComputationColumnFilters = (
+export const persistComputationColumnFilter = (
     studyUuid: UUID,
     computationType: TableType,
     computationSubType: string,
     colId: string,
-    filters: FilterConfig[],
+    filter: FilterConfig | undefined,
     onError: (error: unknown) => void
 ) => {
-    const filter = filters.find((f) => f.column === colId);
     const columnFilterInfos = {
         columnId: colId,
         columnFilterInfos: filter

--- a/src/components/spreadsheet-view/add-spreadsheet/dialogs/add-spreadsheet-utils.ts
+++ b/src/components/spreadsheet-view/add-spreadsheet/dialogs/add-spreadsheet-utils.ts
@@ -58,12 +58,14 @@ export const mapColDefToDto = (colDef: ColumnDefinition, colFilter?: FilterConfi
     precision: colDef.precision,
     formula: colDef.formula,
     dependencies: colDef.dependencies?.length ? JSON.stringify(colDef.dependencies) : undefined,
-    columnFilterInfos: {
-        filterDataType: colFilter?.dataType,
-        filterType: colFilter?.type,
-        filterValue: colFilter?.value ? JSON.stringify(colFilter.value) : undefined,
-        filterTolerance: colFilter?.tolerance,
-    },
+    columnFilterInfos: colFilter
+        ? {
+              filterDataType: colFilter.dataType,
+              filterType: colFilter.type,
+              filterValue: colFilter.value ? JSON.stringify(colFilter.value) : undefined,
+              filterTolerance: colFilter.tolerance,
+          }
+        : undefined,
 });
 
 export const mapColumnsDto = (columns: ColumnDefinitionDto[]) => {

--- a/src/components/spreadsheet-view/columns/column-creation-dialog.tsx
+++ b/src/components/spreadsheet-view/columns/column-creation-dialog.tsx
@@ -27,7 +27,6 @@ import { useForm, UseFormSetError, useWatch } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useDispatch, useSelector } from 'react-redux';
 import { AppDispatch } from 'redux/store';
-import { setUpdateColumnsDefinitions } from 'redux/actions';
 import { hasCyclicDependencies, Item } from './utils/cyclic-dependencies';
 import { COLUMN_TYPES } from 'types/custom-aggrid-types';
 import type { UUID } from 'node:crypto';
@@ -279,47 +278,24 @@ export default function ColumnCreationDialog({
                 return;
             }
 
-            const existingColumn = columnsDefinitions?.find((column) => column.uuid === colUuid);
-
             // We don't include the column filter, so it will be removed when we update the column.
             const formattedParams = {
                 ...newParams,
                 dependencies: newParams.dependencies?.length ? JSON.stringify(newParams.dependencies) : undefined,
             };
 
-            const updateOrCreateColumn =
-                existingColumn && columnDefinition
-                    ? updateSpreadsheetColumn(studyUuid, spreadsheetConfigUuid, columnDefinition.uuid, formattedParams)
-                    : createSpreadsheetColumn(studyUuid, spreadsheetConfigUuid, formattedParams);
-
             // we reset and close the dialog to avoid multiple submissions
             reset(initialColumnCreationForm);
             open.setFalse();
 
-            updateOrCreateColumn
-                .then((uuid) => {
-                    dispatch(
-                        setUpdateColumnsDefinitions({
-                            uuid: tableDefinition.uuid,
-                            value: {
-                                uuid: columnDefinition?.uuid ?? uuid,
-                                id: newParams.id,
-                                name: newParams.name,
-                                type: COLUMN_TYPES[newParams.type],
-                                precision: newParams.precision,
-                                formula: newParams.formula,
-                                dependencies: newParams.dependencies,
-                                visible: true,
-                                locked: existingColumn?.locked,
-                            },
-                        })
-                    );
-                })
-                .catch((error) => {
-                    snackWithFallback(snackError, error, {
-                        headerId: 'spreadsheet/custom_column/error_saving_or_updating_column',
-                    });
+            (columnDefinition
+                ? updateSpreadsheetColumn(studyUuid, spreadsheetConfigUuid, columnDefinition.uuid, formattedParams)
+                : createSpreadsheetColumn(studyUuid, spreadsheetConfigUuid, formattedParams)
+            ).catch((error) => {
+                snackWithFallback(snackError, error, {
+                    headerId: 'spreadsheet/custom_column/error_saving_or_updating_column',
                 });
+            });
         },
         [
             studyUuid,
@@ -330,8 +306,6 @@ export default function ColumnCreationDialog({
             spreadsheetConfigUuid,
             reset,
             open,
-            dispatch,
-            tableDefinition,
             snackError,
         ]
     );

--- a/src/components/spreadsheet-view/columns/column-creation-dialog.tsx
+++ b/src/components/spreadsheet-view/columns/column-creation-dialog.tsx
@@ -29,8 +29,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { AppDispatch } from 'redux/store';
 import { setUpdateColumnsDefinitions } from 'redux/actions';
 import { hasCyclicDependencies, Item } from './utils/cyclic-dependencies';
-import { COLUMN_TYPES, FilterConfig, TableType } from 'types/custom-aggrid-types';
-import { getColumnFiltersFromState } from 'redux/selectors/filter-selectors';
+import { COLUMN_TYPES } from 'types/custom-aggrid-types';
 import type { UUID } from 'node:crypto';
 import { ColumnDefinition, SpreadsheetTabDefinition } from '../types/spreadsheet.type';
 import {
@@ -50,7 +49,6 @@ import { FloatingPopoverTreeviewWrapper } from './floating-treeview-list/floatin
 import { isFormulaContentSizeOk } from './utils/formula-validator';
 import { MAX_FORMULA_CHARACTERS } from '../constants';
 import InfoIcon from '@mui/icons-material/Info';
-import { persistSpreadsheetColumnFilters } from './utils/persist-spreadsheet-column-filters';
 
 export type ColumnCreationDialogProps = {
     open: UseStateBooleanReturn;
@@ -226,18 +224,6 @@ export default function ColumnCreationDialog({
         />
     );
 
-    const filters = useSelector<AppState, FilterConfig[] | undefined>((state) =>
-        getColumnFiltersFromState(state, TableType.Spreadsheet, spreadsheetConfigUuid)
-    );
-
-    const persistFilters = useCallback(
-        (studyUuid: UUID, newFilters: FilterConfig[]) => {
-            const onError = (error: unknown) => snackWithFallback(snackError, error);
-            persistSpreadsheetColumnFilters(studyUuid, spreadsheetConfigUuid, columnDefinition, newFilters, onError);
-        },
-        [spreadsheetConfigUuid, columnDefinition, snackError]
-    );
-
     const validateParams = (
         columnsDefinitions: ColumnDefinition[],
         newParams: ColumnCreationForm,
@@ -294,22 +280,15 @@ export default function ColumnCreationDialog({
             }
 
             const existingColumn = columnsDefinitions?.find((column) => column.uuid === colUuid);
-            let isUpdate = false;
 
-            // If we update the column, we remove its filters
-            if (existingColumn) {
-                isUpdate = true;
-                const updatedFilters = filters?.filter((filter) => filter.column !== existingColumn.id) ?? [];
-                persistFilters(studyUuid, updatedFilters);
-            }
-
+            // We don't include the column filter, so it will be removed when we update the column.
             const formattedParams = {
                 ...newParams,
                 dependencies: newParams.dependencies?.length ? JSON.stringify(newParams.dependencies) : undefined,
             };
 
             const updateOrCreateColumn =
-                isUpdate && columnDefinition
+                existingColumn && columnDefinition
                     ? updateSpreadsheetColumn(studyUuid, spreadsheetConfigUuid, columnDefinition.uuid, formattedParams)
                     : createSpreadsheetColumn(studyUuid, spreadsheetConfigUuid, formattedParams);
 
@@ -351,8 +330,6 @@ export default function ColumnCreationDialog({
             spreadsheetConfigUuid,
             reset,
             open,
-            filters,
-            persistFilters,
             dispatch,
             tableDefinition,
             snackError,

--- a/src/components/spreadsheet-view/columns/column-creation-dialog.tsx
+++ b/src/components/spreadsheet-view/columns/column-creation-dialog.tsx
@@ -25,8 +25,7 @@ import {
 } from '@gridsuite/commons-ui';
 import { useForm, UseFormSetError, useWatch } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useDispatch, useSelector } from 'react-redux';
-import { AppDispatch } from 'redux/store';
+import { useSelector } from 'react-redux';
 import { hasCyclicDependencies, Item } from './utils/cyclic-dependencies';
 import { COLUMN_TYPES } from 'types/custom-aggrid-types';
 import type { UUID } from 'node:crypto';
@@ -102,7 +101,6 @@ export default function ColumnCreationDialog({
     );
 
     const { handleSubmit, reset } = formMethods;
-    const dispatch = useDispatch<AppDispatch>();
 
     const intl = useIntl();
 

--- a/src/components/spreadsheet-view/columns/utils/persist-spreadsheet-column-filter.ts
+++ b/src/components/spreadsheet-view/columns/utils/persist-spreadsheet-column-filter.ts
@@ -10,18 +10,17 @@ import { ColumnDefinition } from '../../types/spreadsheet.type';
 import { updateSpreadsheetColumn } from 'services/study/study-config';
 import { mapColDefToDto } from '../../add-spreadsheet/dialogs/add-spreadsheet-utils';
 
-export const persistSpreadsheetColumnFilters = (
+export const persistSpreadsheetColumnFilter = (
     studyUuid: UUID,
     tabUuid: UUID,
     colDef: ColumnDefinition | undefined,
-    filters: FilterConfig[],
+    filter: FilterConfig | undefined,
     onError: (error: unknown) => void
 ) => {
     if (!colDef) {
         return;
     }
-    const colFilter = filters.find((f) => f.column === colDef.id);
-    const columnDto = mapColDefToDto(colDef, colFilter);
+    const columnDto = mapColDefToDto(colDef, filter);
     updateSpreadsheetColumn(studyUuid, tabUuid, colDef.uuid, columnDto).catch((error) => {
         onError(error);
     });

--- a/src/components/spreadsheet-view/columns/utils/persist-spreadsheet-column-filter.ts
+++ b/src/components/spreadsheet-view/columns/utils/persist-spreadsheet-column-filter.ts
@@ -14,13 +14,13 @@ export const persistSpreadsheetColumnFilter = (
     studyUuid: UUID,
     tabUuid: UUID,
     colDef: ColumnDefinition | undefined,
-    filter: FilterConfig | undefined,
+    colFilter: FilterConfig | undefined,
     onError: (error: unknown) => void
 ) => {
     if (!colDef) {
         return;
     }
-    const columnDto = mapColDefToDto(colDef, filter);
+    const columnDto = mapColDefToDto(colDef, colFilter);
     updateSpreadsheetColumn(studyUuid, tabUuid, colDef.uuid, columnDto).catch((error) => {
         onError(error);
     });


### PR DESCRIPTION
## Summary
- Drop the filter-clearing logic from `ColumnCreationDialog`: omitting `columnFilterInfos` on update is now what triggers the backend to reset the filter. **It also removes an unnecessary HTTP call and fix a potential bug reseting the previous column informations.**
- Rename `persistSpreadsheetColumnFilters` / `persistComputationColumnFilters` to their singular form and pass a single `FilterConfig` instead of the full filters array.
- Make `mapColDefToDto` emit an undefined `columnFilterInfos` when no filter is provided.