### PR TITLE
Remove unused moveModification translation

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1587,6 +1587,5 @@
     "activateModification" : "Activate network modification",
     "deactivateModification" : "Deactivate network modification",
     "deselectModification": "Deselect modification",
-    "selectModification": "Select modification",
-    "moveModification": "Move modification"
+    "selectModification": "Select modification"
 } 

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1581,6 +1581,5 @@
     "activateModification": "Activer la modification réseau",
     "deactivateModification": "Désactiver la modification réseau",
     "deselectModification": "Désélectionner la modification",
-    "selectModification": "Sélectionner la modification",
-    "moveModification": "Déplacer la modification"
+    "selectModification": "Sélectionner la modification"
 }


### PR DESCRIPTION
## Summary

Removes the `moveModification` translation key from `en.json` and `fr.json`. The key was only referenced by the drag-handle Tooltip on the network modification row, which is being removed in [commons-ui#1113](https://github.com/gridsuite/commons-ui/pull/1113). No other references remain in the codebase.

## Related

- Depends on [commons-ui#1113](https://github.com/gridsuite/commons-ui/pull/1113) — this translation becomes dead once that PR merges.