### PR TITLE
fix(Estim): active weights parameters must be positive

### DIFF
--- a/src/components/dialogs/parameters/state-estimation/state-estimation-parameters-utils.ts
+++ b/src/components/dialogs/parameters/state-estimation/state-estimation-parameters-utils.ts
@@ -318,11 +318,11 @@ export const stateEstimationParametersFormSchema = yup.object().shape({
                 yup.object().shape({
                     [VOLTAGE_LEVEL]: yup.string().required(),
                     [WEIGHT_V]: yup.number().required().min(0).label(WEIGHT_V),
-                    [WEIGHT_ACT_TRANSIT]: yup.number().required().max(0).label(WEIGHT_ACT_TRANSIT),
+                    [WEIGHT_ACT_TRANSIT]: yup.number().required().min(0).label(WEIGHT_ACT_TRANSIT),
                     [WEIGHT_REA_TRANSIT]: yup.number().required().min(0).label(WEIGHT_REA_TRANSIT),
-                    [WEIGHT_ACT_PROD]: yup.number().required().max(0).label(WEIGHT_ACT_PROD),
+                    [WEIGHT_ACT_PROD]: yup.number().required().min(0).label(WEIGHT_ACT_PROD),
                     [WEIGHT_REA_PROD]: yup.number().required().min(0).label(WEIGHT_REA_PROD),
-                    [WEIGHT_ACT_LOAD]: yup.number().required().max(0).label(WEIGHT_ACT_LOAD),
+                    [WEIGHT_ACT_LOAD]: yup.number().required().min(0).label(WEIGHT_ACT_LOAD),
                     [WEIGHT_REA_LOAD]: yup.number().required().min(0).label(WEIGHT_REA_LOAD),
                     [WEIGHT_IN]: yup.number().required().min(0).label(WEIGHT_IN),
                 })


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
With powsybl 2026.0.0, active weights parameters must be positive (rather than negative before).



