### PR TITLE
Fix(tabular): empty shunt compensator maxQAtNominalV in prefilled CSV

### DIFF
--- a/src/components/dialogs/network-modifications/tabular/generation/utils.ts
+++ b/src/components/dialogs/network-modifications/tabular/generation/utils.ts
@@ -184,7 +184,7 @@ export const mapShuntCompensatorToFormFields = (shuntCompensator: Record<string,
     return {
         ...formattedCompensator,
         [MAX_Q_AT_NOMINAL_V]:
-            Number(formattedCompensator.qatNominalV) * Number(formattedCompensator.maximumSectionCount),
+            Number(formattedCompensator.qAtNominalV) * Number(formattedCompensator.maximumSectionCount),
     };
 };
 


### PR DESCRIPTION
Fix typo qatNominalV -> qAtNominalV in shunt compensator prefill
