### PR TITLE
fix shunt type in prefilled csv

### DIFF
--- a/src/components/dialogs/network-modifications/tabular/generation/utils.ts
+++ b/src/components/dialogs/network-modifications/tabular/generation/utils.ts
@@ -176,9 +176,7 @@ export const mapShuntCompensatorToFormFields = (shuntCompensator: Record<string,
 
     if (formattedCompensator.type === undefined) {
         formattedCompensator.type =
-            formattedCompensator.bPerSection > 0
-                ? SHUNT_COMPENSATOR_TYPES.CAPACITOR.id
-                : SHUNT_COMPENSATOR_TYPES.REACTOR.id;
+            formattedCompensator.b > 0 ? SHUNT_COMPENSATOR_TYPES.CAPACITOR.id : SHUNT_COMPENSATOR_TYPES.REACTOR.id;
     }
 
     return {

--- a/src/components/dialogs/network-modifications/tabular/generation/utils.ts
+++ b/src/components/dialogs/network-modifications/tabular/generation/utils.ts
@@ -176,7 +176,9 @@ export const mapShuntCompensatorToFormFields = (shuntCompensator: Record<string,
 
     if (formattedCompensator.type === undefined) {
         formattedCompensator.type =
-            formattedCompensator.b > 0 ? SHUNT_COMPENSATOR_TYPES.CAPACITOR.id : SHUNT_COMPENSATOR_TYPES.REACTOR.id;
+            formattedCompensator.bPerSection > 0
+                ? SHUNT_COMPENSATOR_TYPES.CAPACITOR.id
+                : SHUNT_COMPENSATOR_TYPES.REACTOR.id;
     }
 
     return {

--- a/src/components/dialogs/network-modifications/tabular/generation/utils.ts
+++ b/src/components/dialogs/network-modifications/tabular/generation/utils.ts
@@ -176,7 +176,7 @@ export const mapShuntCompensatorToFormFields = (shuntCompensator: Record<string,
 
     if (formattedCompensator.type === undefined) {
         formattedCompensator.type =
-            formattedCompensator.maxSusceptance > 0
+            formattedCompensator.bPerSection > 0
                 ? SHUNT_COMPENSATOR_TYPES.CAPACITOR.id
                 : SHUNT_COMPENSATOR_TYPES.REACTOR.id;
     }


### PR DESCRIPTION
## PR Summary
- shunt for prefilled csv have a type CONDENSOR or REACTOR based on maxSusceptance attribute, or this attribute does not exist, so it will be based on bPerSection, it assumes that shunts have linear model



