### PR TITLE
fix: reset equipment ID on fetch failure in modification dialogs

### DIFF
--- a/src/components/dialogs/network-modifications/battery/modification/battery-modification-dialog.tsx
+++ b/src/components/dialogs/network-modifications/battery/modification/battery-modification-dialog.tsx
@@ -172,6 +172,9 @@ export default function BatteryModificationDialog({
                     })
                     .catch(() => {
                         setDataFetchStatus(FetchStatus.FAILED);
+                        reset((formValues) => ({ ...formValues, [FieldConstants.EQUIPMENT_ID]: equipmentId }), {
+                            keepDirty: true,
+                        });
                         if (editData?.equipmentId !== equipmentId) {
                             setBatteryToModify(null);
                         }

--- a/src/components/dialogs/network-modifications/shunt-compensator/modification/shunt-compensator-modification-dialog.tsx
+++ b/src/components/dialogs/network-modifications/shunt-compensator/modification/shunt-compensator-modification-dialog.tsx
@@ -151,6 +151,9 @@ export default function ShuntCompensatorModificationDialog({
                     })
                     .catch(() => {
                         setDataFetchStatus(FetchStatus.FAILED);
+                        reset((formValues) => ({ ...formValues, [FieldConstants.EQUIPMENT_ID]: equipmentId }), {
+                            keepDirty: true,
+                        });
                         if (editData?.equipmentId !== equipmentId) {
                             setShuntCompensatorInfos(null);
                         }


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->



