### PR TITLE
Bump commons-ui to 0.222.0 and remove rowDrag from tabular form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@gridsuite/commons-ui": "0.221.1",
+                "@gridsuite/commons-ui": "0.222.0",
                 "@hello-pangea/dnd": "^18.0.1",
                 "@hookform/resolvers": "^4.1.3",
                 "@mui/icons-material": "^6.5.0",
@@ -3288,9 +3288,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.221.1",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.221.1.tgz",
-            "integrity": "sha512-NxfNyKwRixhFpjI+ziecu/eRA8+BWAS5wYgUH4+PFBD9k7QVD6tyOmDXUKEBy2wWwRCM9jhJmob4YvWELMB7tg==",
+            "version": "0.222.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.222.0.tgz",
+            "integrity": "sha512-n4JCdSw1O6042KQUh10EL6Jf/D4H0pxDXEPa6TLU7jlKv6Gfg0xrbpmM3XUFPUhqTXbWxyLeMzFXfXwhkZuAMg==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^33.3.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gridsuite/commons-ui": "0.221.1",
+        "@gridsuite/commons-ui": "0.222.0",
         "@hello-pangea/dnd": "^18.0.1",
         "@hookform/resolvers": "^4.1.3",
         "@mui/icons-material": "^6.5.0",

--- a/src/components/dialogs/network-modifications/tabular/tabular-form.tsx
+++ b/src/components/dialogs/network-modifications/tabular/tabular-form.tsx
@@ -416,7 +416,6 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
                 };
                 if (field.id === EQUIPMENT_ID) {
                     columnDef.pinned = true;
-                    columnDef.rowDrag = true;
                 }
                 switch (field.type) {
                     case NUMBER:


### PR DESCRIPTION
Bump `@gridsuite/commons-ui` from 0.221.1 to 0.222.0.

Remove the `rowDrag` option on the equipment id column of the tabular network modification form.