### PR TITLE
Update limit sets tabular CSV template with all modification options

### DIFF
--- a/src/translations/dynamic/csv-locale-en.ts
+++ b/src/translations/dynamic/csv-locale-en.ts
@@ -27,7 +27,7 @@ const csv_locale_en = {
     'TabularModificationSkeletonComment.SHUNT_COMPENSATOR':
         '#For each shunt compensator it is possible to modify either the maximum reactive power (and the type) or the maximum susceptance. In case of conflicting input the maximum susceptance will be ignored.,,true | false,,TOP | BOTTOM,,,,REACTOR | CAPACITOR,,',
     TabularLimitSetsModificationSkeletonComment:
-        '#;SIDE1 | SIDE2 | EQUIPMENT;;true | false;;ADD | MODIFY | REPLACE;ADD | MODIFY | DELETE | REPLACE taken into account only when modificationType is set to MODIFY',
+        '#;SIDE1 | SIDE2 | EQUIPMENT;;true | false;;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE taken into account only when modificationType is set to MODIFY',
 };
 
 export default csv_locale_en;

--- a/src/translations/dynamic/csv-locale-en.ts
+++ b/src/translations/dynamic/csv-locale-en.ts
@@ -27,7 +27,7 @@ const csv_locale_en = {
     'TabularModificationSkeletonComment.SHUNT_COMPENSATOR':
         '#For each shunt compensator it is possible to modify either the maximum reactive power (and the type) or the maximum susceptance. In case of conflicting input the maximum susceptance will be ignored.,,true | false,,TOP | BOTTOM,,,,REACTOR | CAPACITOR,,',
     TabularLimitSetsModificationSkeletonComment:
-        '#;SIDE1 | SIDE2 | EQUIPMENT;;true | false;;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE taken into account only when modificationType is set to MODIFY',
+        '#;SIDE1 | SIDE2 | EQUIPMENT;;true | false;;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE (taken into account only when modificationType is set on modifying)',
 };
 
 export default csv_locale_en;

--- a/src/translations/dynamic/csv-locale-fr.ts
+++ b/src/translations/dynamic/csv-locale-fr.ts
@@ -27,7 +27,7 @@ const csv_locale_fr = {
     'TabularModificationSkeletonComment.SHUNT_COMPENSATOR':
         '#Pour chaque MCS il est possible de modifier soit la puissance réactive installée (et le type) soit la susceptance installée. En cas de conflit la susceptance installée sera ignorée.;;true | false;;TOP | BOTTOM;;;;REACTOR | CAPACITOR;;',
     TabularLimitSetsModificationSkeletonComment:
-        '#;SIDE1 | SIDE2 | EQUIPMENT;;true | false;;ADD | MODIFY | REPLACE;ADD | MODIFY | DELETE | REPLACE pris en compte uniquement lorsque modificationType est défini à MODIFY',
+        '#;SIDE1 | SIDE2 | EQUIPMENT;;true | false;;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE pris en compte uniquement lorsque modificationType est défini à MODIFY',
 };
 
 export default csv_locale_fr;

--- a/src/translations/dynamic/csv-locale-fr.ts
+++ b/src/translations/dynamic/csv-locale-fr.ts
@@ -27,7 +27,7 @@ const csv_locale_fr = {
     'TabularModificationSkeletonComment.SHUNT_COMPENSATOR':
         '#Pour chaque MCS il est possible de modifier soit la puissance réactive installée (et le type) soit la susceptance installée. En cas de conflit la susceptance installée sera ignorée.;;true | false;;TOP | BOTTOM;;;;REACTOR | CAPACITOR;;',
     TabularLimitSetsModificationSkeletonComment:
-        '#;SIDE1 | SIDE2 | EQUIPMENT;;true | false;;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE pris en compte uniquement lorsque modificationType est défini à MODIFY',
+        '#;SIDE1 | SIDE2 | EQUIPMENT;;true | false;;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE;ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE (pris en compte uniquement lorsque modificationType est défini sur modifier)',
 };
 
 export default csv_locale_fr;


### PR DESCRIPTION
## Context

The CSV template generated for tabular limit set modifications was out of date: the comment line only displayed a subset of the modification types and did not match the values actually accepted on import.

Both modification type columns (`modificationType` and `temporaryLimitsModificationType`) already accept the full set of options through their field definitions (`Object.values(...)`), but the template comment only advertised `ADD | MODIFY | REPLACE` / `ADD | MODIFY | DELETE | REPLACE`.

## Change

Update the `TabularLimitSetsModificationSkeletonComment` translation (EN and FR) so the generated template lists all accepted options for both columns:

`ADD | MODIFY | MODIFY_OR_ADD | DELETE | REPLACE`