### PR TITLE
Reduce NAD re-renders and DOM work, and configure edges adaptive zoom thresholds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@mui/material": "^6.5.0",
                 "@mui/x-charts": "^8.21.0",
                 "@mui/x-tree-view": "^8.21.0",
-                "@powsybl/network-viewer": "3.5.0",
+                "@powsybl/network-viewer": "3.5.1",
                 "@reduxjs/toolkit": "^2.9.0",
                 "@svgdotjs/svg.js": "^3.2.4",
                 "@tanstack/react-table": "^8.21.3",
@@ -5262,9 +5262,9 @@
             }
         },
         "node_modules/@powsybl/network-map-layers": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/@powsybl/network-map-layers/-/network-map-layers-3.5.0.tgz",
-            "integrity": "sha512-JIYJ+fylX0HnKxtrkOKht1YeCXfev95XvV4JJ5YysSCAbCKywEqgtGEORRSJFrvTj1dVG29WxsGWjhVDcTo2LA==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/@powsybl/network-map-layers/-/network-map-layers-3.5.1.tgz",
+            "integrity": "sha512-JJCzh4ehDlDMsDxe8FC0KH1ep7P4X8gOwYJVdD9KSPD/2Yy1OgXGtD/VpEn9sL0wO8JHJS/mBLzWMO+4TSKFfQ==",
             "license": "MPL-2.0",
             "dependencies": {
                 "cheap-ruler": "^4.0.0",
@@ -5282,9 +5282,9 @@
             }
         },
         "node_modules/@powsybl/network-map-layers/node_modules/type-fest": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+            "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
                 "tagged-tag": "^1.0.0"
@@ -5297,9 +5297,9 @@
             }
         },
         "node_modules/@powsybl/network-viewer": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/@powsybl/network-viewer/-/network-viewer-3.5.0.tgz",
-            "integrity": "sha512-zPLGvtDcaNkiUhfC9HuQNmJ4BQrvuBq5iS5tvY0YAHyWC0hzuXh6IiWsXR7vFEBciSndKpvSBnmWs/vsGuHMgQ==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/@powsybl/network-viewer/-/network-viewer-3.5.1.tgz",
+            "integrity": "sha512-qOlJpRCSKGqr8+z5oBgM/hZw7oDkf9f1gV57P19QRRHLQYDLyd1HxPIbkLAS+WIzcoKFExPvRTCYLq5ZGgofvw==",
             "license": "MPL-2.0",
             "workspaces": [
                 "packages/*"
@@ -5313,8 +5313,8 @@
                 "@luma.gl/core": "~9.2.0",
                 "@luma.gl/engine": "~9.2.0",
                 "@mapbox/mapbox-gl-draw": "<1.5.0",
-                "@powsybl/network-map-layers": "^3.5.0",
-                "@powsybl/network-viewer-core": "^3.5.0",
+                "@powsybl/network-map-layers": "~3.5.1",
+                "@powsybl/network-viewer-core": "~3.5.1",
                 "@turf/boolean-point-in-polygon": "^7.2.0",
                 "cheap-ruler": "^4.0.0",
                 "geolib": "^3.3.4",
@@ -5333,9 +5333,9 @@
             }
         },
         "node_modules/@powsybl/network-viewer-core": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/@powsybl/network-viewer-core/-/network-viewer-core-3.5.0.tgz",
-            "integrity": "sha512-AGF+qVBXC7jToHrmxatU/Wuc/Ji92YZDucfzXajXfEG/Lhrh5yC1bFRoE19mKa2QW0coE3lD6BSumlx/m/qeNQ==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/@powsybl/network-viewer-core/-/network-viewer-core-3.5.1.tgz",
+            "integrity": "sha512-ifvLxGtZDK1s4OlWmGJ1x++lrmUP8WLR59owOiVLwU78sDCH0kWkd9GB8GRM6dtrjXMiwxPpGB5EnHqCMn9ADw==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@svgdotjs/svg.js": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@mui/material": "^6.5.0",
         "@mui/x-charts": "^8.21.0",
         "@mui/x-tree-view": "^8.21.0",
-        "@powsybl/network-viewer": "3.5.0",
+        "@powsybl/network-viewer": "3.5.1",
         "@reduxjs/toolkit": "^2.9.0",
         "@svgdotjs/svg.js": "^3.2.4",
         "@tanstack/react-table": "^8.21.3",

--- a/src/components/grid-layout/cards/diagrams/diagram-utils.ts
+++ b/src/components/grid-layout/cards/diagrams/diagram-utils.ts
@@ -22,7 +22,7 @@ export const MAX_HEIGHT_NETWORK_AREA_DIAGRAM = Infinity;
 
 // Array of zoom levels used to determine level-of-detail rendering by applying in the network-viewer the
 // corresponding css class 'nad-zoom-{level}' to the NAD's SVG.
-export const NAD_ZOOM_LEVELS = [0, 500, 1000, 2500, 3500, 5000, 6000, 9000, 12000, 15000];
+export const NAD_ZOOM_LEVELS = [0, 500, 1000, 2500, 3000, 3500, 5000, 6000, 9000, 12000, 15000];
 
 // be careful when using this method because there are treatments made on purpose
 export function getEquipmentTypeFromFeederType(feederType: FeederTypes | null): {

--- a/src/components/grid-layout/cards/diagrams/networkAreaDiagram/network-area-diagram-content.tsx
+++ b/src/components/grid-layout/cards/diagrams/networkAreaDiagram/network-area-diagram-content.tsx
@@ -126,11 +126,9 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
     const [isEditNadMode, setIsEditNadMode] = useState<boolean>(false);
     const workspaceId = useSelector(selectActiveWorkspaceId);
 
-    // refs to keep useLayoutEffect and callbacks stable
+    // ref to keep useLayoutEffect and callbacks stable
     const isEditNadModeRef = useRef(isEditNadMode);
-    const positionsRef = useRef(positions);
     isEditNadModeRef.current = isEditNadMode;
-    positionsRef.current = positions;
 
     const initialLocalStorageViewBox = useRef(
         (() => {
@@ -387,7 +385,7 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
     );
 
     const handleMoveNode = useEffectEvent((equipmentId: string, nodeId: string, x: number, y: number) => {
-        const updatedPositions = positionsRef.current.map((position) =>
+        const updatedPositions = positions.map((position) =>
             position.voltageLevelId === equipmentId ? { ...position, xPosition: x, yPosition: y } : position
         );
         onUpdatePositions(updatedPositions);
@@ -395,7 +393,7 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
 
     const handleMoveTextnode = useEffectEvent(
         (equipmentId: string, vlNodeId: string, textNodeId: string, shiftX: number, shiftY: number) => {
-            const updatedPositions = positionsRef.current.map((position) =>
+            const updatedPositions = positions.map((position) =>
                 position.voltageLevelId === equipmentId
                     ? { ...position, xLabelPosition: shiftX, yLabelPosition: shiftY }
                     : position
@@ -510,25 +508,6 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
                 nadViewerParameters
             );
 
-            // Repositioning the nodes with specified positions.
-            // Skip nodes already at their SVG-rendered position to avoid redundant DOM work.
-            if (positionsRef.current.length > 0) {
-                const svgMetaPositionMap = new Map(
-                    svgMetadata?.nodes.map((node) => [node.equipmentId, { x: node.x, y: node.y }]) ?? []
-                );
-                for (const position of positionsRef.current) {
-                    if (position.xPosition !== undefined && position.yPosition !== undefined) {
-                        const metaPos = svgMetaPositionMap.get(position.voltageLevelId);
-                        if (metaPos?.x !== position.xPosition || metaPos.y !== position.yPosition) {
-                            diagramViewer.moveNodeToCoordinates(
-                                position.voltageLevelId,
-                                position.xPosition,
-                                position.yPosition
-                            );
-                        }
-                    }
-                }
-            }
             // We keep a reference of the diagram viewer to get its viewbox for the next render.
             diagramViewerRef.current = diagramViewer;
         }

--- a/src/components/grid-layout/cards/diagrams/networkAreaDiagram/network-area-diagram-content.tsx
+++ b/src/components/grid-layout/cards/diagrams/networkAreaDiagram/network-area-diagram-content.tsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useEffectEvent, useLayoutEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import RunningStatus from 'components/utils/running-status';
 import {
@@ -161,7 +161,7 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
         setShowLabels((oldShowLabels) => !oldShowLabels);
     }, []);
 
-    const handleToggleHover: OnToggleNadHoverCallbackType = useCallback(
+    const handleToggleHover: OnToggleNadHoverCallbackType = useEffectEvent(
         (shouldDisplay: boolean, mousePosition: Point | null, equipmentId: string, equipmentType: string) => {
             // Do not show the hover in edit mode
             if (isEditNadModeRef.current) {
@@ -185,24 +185,20 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
             } else {
                 setShouldDisplayTooltip(false);
             }
-        },
-        []
+        }
     );
 
-    const handleNodeLeftClick: OnSelectNodeCallbackType = useCallback(
-        (equipmentId, nodeId, mousePosition) => {
-            if (mousePosition && !loadingState) {
-                if (isEditNadModeRef.current) {
-                    setSelectedVoltageLevelId(equipmentId);
-                    setShouldDisplayMenu(true);
-                    setMenuAnchorPosition(mousePosition ? { mouseX: mousePosition.x, mouseY: mousePosition.y } : null);
-                } else {
-                    onVoltageLevelClick(equipmentId);
-                }
+    const handleNodeLeftClick: OnSelectNodeCallbackType = useEffectEvent((equipmentId, nodeId, mousePosition) => {
+        if (mousePosition && !loadingState) {
+            if (isEditNadModeRef.current) {
+                setSelectedVoltageLevelId(equipmentId);
+                setShouldDisplayMenu(true);
+                setMenuAnchorPosition(mousePosition ? { mouseX: mousePosition.x, mouseY: mousePosition.y } : null);
+            } else {
+                onVoltageLevelClick(equipmentId);
             }
-        },
-        [onVoltageLevelClick, loadingState]
-    );
+        }
+    });
 
     const handleSaveNadConfig = (directoryData: IElementCreationDialog) => {
         createDiagramConfig(
@@ -277,7 +273,7 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
         onOpenDynamicSimulationEventDialog: handleOpenDynamicSimulationEventDialog,
     });
 
-    const showEquipmentMenu = useCallback(
+    const showEquipmentMenu = useEffectEvent(
         (svgId: string, equipmentId: string, equipmentType: string, mousePosition: Point) => {
             if (isEditNadModeRef.current || !equipmentsWithContextualMenu.includes(equipmentType)) {
                 return;
@@ -336,8 +332,7 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
                     openMenu(convertedType.equipmentType, convertedType.equipmentSubtype ?? null);
                 }
             }
-        },
-        [additionalMetadata, openEquipmentMenu, currentNode?.id, currentRootNetworkUuid, studyUuid, snackError]
+        }
     );
 
     const handleAddVoltageLevel = useCallback(
@@ -391,17 +386,14 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
         [voltageLevelIds, voltageLevelToExpandIds, voltageLevelToOmitIds, onUpdateVoltageLevels]
     );
 
-    const handleMoveNode = useCallback(
-        (equipmentId: string, nodeId: string, x: number, y: number) => {
-            const updatedPositions = positionsRef.current.map((position) =>
-                position.voltageLevelId === equipmentId ? { ...position, xPosition: x, yPosition: y } : position
-            );
-            onUpdatePositions(updatedPositions);
-        },
-        [onUpdatePositions]
-    );
+    const handleMoveNode = useEffectEvent((equipmentId: string, nodeId: string, x: number, y: number) => {
+        const updatedPositions = positionsRef.current.map((position) =>
+            position.voltageLevelId === equipmentId ? { ...position, xPosition: x, yPosition: y } : position
+        );
+        onUpdatePositions(updatedPositions);
+    });
 
-    const handleMoveTextnode = useCallback(
+    const handleMoveTextnode = useEffectEvent(
         (equipmentId: string, vlNodeId: string, textNodeId: string, shiftX: number, shiftY: number) => {
             const updatedPositions = positionsRef.current.map((position) =>
                 position.voltageLevelId === equipmentId
@@ -409,8 +401,7 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
                     : position
             );
             onUpdatePositions(updatedPositions);
-        },
-        [onUpdatePositions]
+        }
     );
 
     const handleReplaceNadConfig = useCallback(
@@ -504,8 +495,13 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
                 onRightClickCallback: showEquipmentMenu,
                 initialViewBox:
                     diagramViewerRef.current?.getViewBox() ?? initialLocalStorageViewBox.current ?? undefined,
-                enableAdaptiveTextZoom: true,
-                adaptiveTextZoomThreshold: 9000,
+                adaptiveTextZoom: {
+                    enabled: true,
+                    threshold: 9000,
+                    edgeMiddleLabelThreshold: 3000,
+                    edgeSideLabelThreshold: 2000,
+                    edgeMiddleArrowThreshold: 8000,
+                },
             };
             const diagramViewer = new NetworkAreaDiagramViewer(
                 svgRef.current,
@@ -514,32 +510,29 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
                 nadViewerParameters
             );
 
-            // Repositioning the nodes with specified positions
+            // Repositioning the nodes with specified positions.
+            // Skip nodes already at their SVG-rendered position to avoid redundant DOM work.
             if (positionsRef.current.length > 0) {
+                const svgMetaPositionMap = new Map(
+                    svgMetadata?.nodes.map((node) => [node.equipmentId, { x: node.x, y: node.y }]) ?? []
+                );
                 for (const position of positionsRef.current) {
                     if (position.xPosition !== undefined && position.yPosition !== undefined) {
-                        diagramViewer.moveNodeToCoordinates(
-                            position.voltageLevelId,
-                            position.xPosition,
-                            position.yPosition
-                        );
+                        const metaPos = svgMetaPositionMap.get(position.voltageLevelId);
+                        if (metaPos?.x !== position.xPosition || metaPos.y !== position.yPosition) {
+                            diagramViewer.moveNodeToCoordinates(
+                                position.voltageLevelId,
+                                position.xPosition,
+                                position.yPosition
+                            );
+                        }
                     }
                 }
             }
             // We keep a reference of the diagram viewer to get its viewbox for the next render.
             diagramViewerRef.current = diagramViewer;
         }
-    }, [
-        svg,
-        svgMetadata,
-        nadPanelId,
-        loadingState,
-        handleMoveNode,
-        handleMoveTextnode,
-        handleNodeLeftClick,
-        handleToggleHover,
-        showEquipmentMenu,
-    ]);
+    }, [svg, svgMetadata, nadPanelId, loadingState]);
 
     const closeMenu = () => {
         setMenuAnchorPosition(null);

--- a/src/nad-index.css
+++ b/src/nad-index.css
@@ -311,16 +311,19 @@ g.nad-disconnected > .nad-disconnected.nad-edge-path {
 :is(.nad-zoom-3500) .nad-text-nodes {
     font-size: 45px;
 }
+:is(.nad-zoom-3000) .nad-text-nodes {
+    font-size: 45px;
+}
 :is(.nad-zoom-2500) .nad-text-nodes {
     font-size: 35px;
 }
-:is( .nad-zoom-3500, .nad-zoom-5000, .nad-zoom-6000) .nad-bus-descr {
+:is( .nad-zoom-3500, .nad-zoom-5000, .nad-zoom-6000, .nad-zoom-3000) .nad-bus-descr {
     display: none;
 }
 :is( .nad-zoom-5000) .nad-permanent-limit-percentage {
     display: none;
 }
-:is(.nad-zoom-2500, .nad-zoom-3500, .nad-zoom-5000) .nad-arrow-out.nad-permanent-limit-percentage {
+:is(.nad-zoom-2500, .nad-zoom-3000, .nad-zoom-3500, .nad-zoom-5000) .nad-arrow-out.nad-permanent-limit-percentage {
     display: inline;
 }
 /* Make arrows scale with zoom */
@@ -328,6 +331,9 @@ g.nad-disconnected > .nad-disconnected.nad-edge-path {
     stroke-width: 2px;
 }
 :is(.nad-zoom-3500) .nad-edge-infos path {
+    stroke-width: 8px;
+}
+:is(.nad-zoom-3000) .nad-edge-infos path {
     stroke-width: 8px;
 }
 .nad-zoom-5000 .nad-edge-infos path {

--- a/src/nad-index.css
+++ b/src/nad-index.css
@@ -148,13 +148,6 @@ g.nad-disconnected > .nad-disconnected.nad-edge-path {
     animation: node-under-blink 0.75s infinite steps(1, start);
 }
 
-/* NETWORK AREA DIAGRAM LEVEL OF DETAIL */
-.nad-edge-infos .nad-active,
-.nad-edge-infos .nad-reactive,
-.nad-edge-infos .nad-permanent-limit-percentage {
-    display:none;
-}
-
 /* Makes the nodes' edges thicker when zooming a lot */
 .nad-zoom-0 {
     :is(
@@ -288,13 +281,6 @@ g.nad-disconnected > .nad-disconnected.nad-edge-path {
     transition: font-size 0.2s ease, stroke-width 0.2s ease;
 }
 
-:is(.nad-zoom-6000, .nad-zoom-5000, .nad-zoom-3500, .nad-zoom-2500, .nad-zoom-1000, .nad-zoom-500, .nad-zoom-0) :is(.nad-active, .nad-permanent-limit-percentage) {
-   display: inline;
-}
-:is(.nad-zoom-1000, .nad-zoom-500, .nad-zoom-0) :is(.nad-reactive) {
-   display: inline;
-}
-
 .nad-zoom-0 .nad-edge-infos text { font-size: 20px; stroke-width: 5px; }
 .nad-zoom-500 .nad-edge-infos text { font-size: 20px; stroke-width: 5px; }
 .nad-zoom-1000 .nad-edge-infos text { font-size: 30px; stroke-width: 5.5px; }
@@ -308,32 +294,20 @@ g.nad-disconnected > .nad-disconnected.nad-edge-path {
 :is(.nad-zoom-6000) .nad-text-nodes {
     font-size: 60px;
 }
-:is(.nad-zoom-3500) .nad-text-nodes {
-    font-size: 45px;
-}
-:is(.nad-zoom-3000) .nad-text-nodes {
+:is(.nad-zoom-3000, .nad-zoom-3500) .nad-text-nodes {
     font-size: 45px;
 }
 :is(.nad-zoom-2500) .nad-text-nodes {
     font-size: 35px;
 }
-:is( .nad-zoom-3500, .nad-zoom-5000, .nad-zoom-6000, .nad-zoom-3000) .nad-bus-descr {
+:is(.nad-zoom-3000, .nad-zoom-3500, .nad-zoom-5000, .nad-zoom-6000) .nad-bus-descr {
     display: none;
-}
-:is( .nad-zoom-5000) .nad-permanent-limit-percentage {
-    display: none;
-}
-:is(.nad-zoom-2500, .nad-zoom-3000, .nad-zoom-3500, .nad-zoom-5000) .nad-arrow-out.nad-permanent-limit-percentage {
-    display: inline;
 }
 /* Make arrows scale with zoom */
 :is(.nad-zoom-2500) .nad-edge-infos path {
     stroke-width: 2px;
 }
-:is(.nad-zoom-3500) .nad-edge-infos path {
-    stroke-width: 8px;
-}
-:is(.nad-zoom-3000) .nad-edge-infos path {
+:is(.nad-zoom-3000, .nad-zoom-3500) .nad-edge-infos path {
     stroke-width: 8px;
 }
 .nad-zoom-5000 .nad-edge-infos path {

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -67,12 +67,14 @@ export const getBaseVoltagesCssVars = (
 
         const higherLevels = baseVoltages
             .filter((v) => getVoltageLevel(v.name) > getVoltageLevel(interval.name))
-            .map((v) => `.nad-${v.name}.nad-winding`)
+            .map((v) => `> .nad-${v.name}.nad-winding`)
             .join(', ');
 
+        // :has(> X) only inspects direct children, not the whole subtree like :has(X) which is extremely costly on large digrams
+        // windings and the --vl-color-inheriting .nad-pst-arrow are always direct children here
         const groupWithPstSelector = higherLevels
-            ? `g:has(.nad-${interval.name}.nad-winding):not(:has(${higherLevels}))`
-            : `g:has(.nad-${interval.name}.nad-winding)`;
+            ? `g:has(> .nad-${interval.name}.nad-winding):not(:has(${higherLevels}))`
+            : `g:has(> .nad-${interval.name}.nad-winding)`;
 
         css[groupWithPstSelector] = { '--vl-color': themeColors.default };
 


### PR DESCRIPTION
- Replace useCallback with useEffectEvent for NAD event handlers (hover, node click, equipment menu, node/text-node move) to avoid unnecessary reconstruction of NetworkAreaDiagramViewer on tree node change
- Remove redundant moveNodeToCoordinates calls on diagram load, the node postions are already stored in backend
- Optimize :has() selectors in colors.ts to only inspect direct nad-winding children, avoiding costly subtree scans on large
- diagrams.
- Configure the new NetworkAreaDiagramViewer edge infos adaptive zoom thresholds