### PR TITLE
Fix security analysis results crash on rapid N / N-K tab switching

### DIFF
--- a/src/components/results/securityanalysis/security-analysis-result-n.tsx
+++ b/src/components/results/securityanalysis/security-analysis-result-n.tsx
@@ -25,7 +25,9 @@ export const SecurityAnalysisResultN: FunctionComponent<SecurityAnalysisResultNP
     const intl: IntlShape = useIntl();
 
     const rows = useMemo(() => {
-        return result
+        // Defensive guard: the N tab expects an array; a stale paginated result
+        // ({ content, totalElements }) from the N-K tab must not reach result.map.
+        return Array.isArray(result)
             ? result.map((preContingencyResult: PreContingencyResult) => {
                   const { limitViolation, subjectId } = preContingencyResult;
                   return {

--- a/src/components/use-node-data.tsx
+++ b/src/components/use-node-data.tsx
@@ -111,22 +111,36 @@ export function useNodeData<T, R = T>({
     const nodeUuidRef = useRef<UUID>(undefined);
     const rootNetworkUuidRef = useRef<UUID>(undefined);
     const lastUpdateRef = useRef<LastUpdateParams<T>>(undefined);
+    // Monotonic id identifying the latest in-flight request. A response is only
+    // applied when its id is still the latest one, so an out-of-order response
+    // from a previous fetcher (e.g. another node, another root network, or
+    // another tab with a different result shape) cannot overwrite the current
+    // result and crash consumers.
+    const requestIdRef = useRef<number>(0);
 
     const update = useCallback(() => {
         nodeUuidRef.current = nodeUuid;
         rootNetworkUuidRef.current = rootNetworkUuid;
+        const requestId = ++requestIdRef.current;
+        const isLatestRequest = () => requestId === requestIdRef.current;
         setIsLoading(true);
         setErrorMessage(undefined);
         fetcher?.(studyUuid, nodeUuid, rootNetworkUuid)
             .then((res) => {
-                if (nodeUuidRef.current === nodeUuid && rootNetworkUuidRef.current === rootNetworkUuid) {
+                if (isLatestRequest()) {
                     setResult(resultConverter(res) ?? undefined);
                 }
             })
             .catch((err) => {
-                setErrorMessage(err.message);
+                if (isLatestRequest()) {
+                    setErrorMessage(err.message);
+                }
             })
-            .finally(() => setIsLoading(false));
+            .finally(() => {
+                if (isLatestRequest()) {
+                    setIsLoading(false);
+                }
+            });
     }, [nodeUuid, fetcher, rootNetworkUuid, studyUuid, resultConverter]);
 
     // Debounce the update to avoid excessive calls


### PR DESCRIPTION
## Problem

The security analysis results floating window could crash with `TypeError: e.map is not a function` after several rapid switches between the **N** and **N-K** tabs (more easily triggered once a global filter, column filters and sorts on the load columns were applied, which slow the requests down).

## Root cause

Both tabs are backed by a single `useNodeData` hook whose `fetcher` changes per tab, but the two fetchers return **different shapes**:

- **N** → an array `PreContingencyResult[]`
- **N-K** → a paginated object `{ content, totalElements }`

On rapid tab switching, two requests to different endpoints are in flight. The in-flight guard in `update` only checked `nodeUuid`/`rootNetworkUuid` (neither changes when switching tabs), so an out-of-order response from the previous tab's fetcher could overwrite `result`. When the paginated N-K object landed while the N tab was shown, `security-analysis-result-n.tsx` ran `result.map(...)` on an object and threw.

## Fix

- `use-node-data.tsx`: guard responses with a monotonic request id; only the latest in-flight request is applied. Since `update` is recreated whenever the node, root network or fetcher changes, any stale response is discarded — this also covers the previous node/root-network checks. Loading and error state are gated the same way.
- `security-analysis-result-n.tsx`: defensive `Array.isArray(result)` check before mapping.