### PR TITLE
Allow recovery after invalid tabular CSV import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
-                "@gridsuite/commons-ui": "0.235.0",
+                "@gridsuite/commons-ui": "0.236.0",
                 "@hello-pangea/dnd": "^18.0.1",
                 "@hookform/resolvers": "^4.1.3",
                 "@mui/icons-material": "^6.5.0",
@@ -3287,9 +3287,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.235.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.235.0.tgz",
-            "integrity": "sha512-LyrKeyqXkzZn0ALTN1ZWdnGpD0NqXFZyUCx5weZLC/JnGoPpuNC5nVDBEUqkp0/hHLSmw1Debxu6QJYzFiq/jg==",
+            "version": "0.236.0",
+            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.236.0.tgz",
+            "integrity": "sha512-MFbfFK/preckX5EzVnjTaxNMNMezaC3eTnQw9x/Bjj479sxedX8PUukEVnYFqVJ45v8z+82Gp8GbdgFffZfiag==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^35.3.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@gridsuite/commons-ui": "0.235.0",
+        "@gridsuite/commons-ui": "0.236.0",
         "@hello-pangea/dnd": "^18.0.1",
         "@hookform/resolvers": "^4.1.3",
         "@mui/icons-material": "^6.5.0",

--- a/src/components/dialogs/network-modifications/tabular/tabular-common.ts
+++ b/src/components/dialogs/network-modifications/tabular/tabular-common.ts
@@ -252,6 +252,24 @@ export const isFieldTypeOk = (value: any, fieldDefinition: { type?: string; opti
     return true;
 };
 
+/**
+ * Sanitize a CSV cell value before injecting it into the table:
+ * - a mandatory boolean (checkbox) cell with no/invalid value defaults to `false`
+ *   (an empty checkbox cannot be distinguished from `false`),
+ * - any other value with a wrong format is dropped (replaced by `null`) so invalid data
+ *   is never injected,
+ * - otherwise the value is kept as-is (including non-typed `property_*` columns).
+ */
+export const sanitizeRowValue = (value: any, fieldDefinition: TabularField | undefined): any => {
+    if (fieldDefinition?.type === BOOLEAN && fieldDefinition.required && typeof value !== 'boolean') {
+        return false;
+    }
+    if (!isFieldTypeOk(value, fieldDefinition)) {
+        return null;
+    }
+    return value;
+};
+
 export const transformIfFrenchNumber = (value: string, language: string): string => {
     value = value.trim();
     // Only transform if we're in French mode and the value is a number that has a comma

--- a/src/components/dialogs/network-modifications/tabular/tabular-form.tsx
+++ b/src/components/dialogs/network-modifications/tabular/tabular-form.tsx
@@ -46,13 +46,14 @@ import {
     generateCommentLines,
     isFieldTypeOk,
     PredefinedEquipmentProperties,
+    sanitizeRowValue,
     setFieldTypeError,
     TabularField,
     TabularModificationType,
     transformIfFrenchNumber,
 } from './tabular-common';
 import { ColDef } from 'ag-grid-community';
-import { ENUM, NUMBER } from '../../../network/constants';
+import { BOOLEAN, ENUM, NUMBER } from '../../../network/constants';
 import { TABULAR_CREATION_FIELDS } from './tabular-creation-utils';
 import { TABULAR_MODIFICATION_FIELDS } from './tabular-modification-utils';
 import { useFilterCsvGenerator } from './use-filter-csv-generator';
@@ -99,6 +100,7 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
 
     const [selectedFile, setSelectedFile] = useState<File | undefined>();
     const [fileErrorMessage, setFileErrorMessage] = useState<string | undefined>();
+    const [fileWarningMessage, setFileWarningMessage] = useState<string | undefined>();
 
     const parseConfig = useMemo<Partial<Papa.ParseConfig<Record<string, unknown>>>>(
         () => ({
@@ -137,6 +139,19 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
                     )
                     .some(([result, key, value]) => {
                         const fieldDef = csvFields.find((field) => field.id === key);
+                        // boolean values are never blocking: an invalid one is silently replaced by
+                        // false (see sanitizeRowValue), we only warn the user it was replaced.
+                        if (fieldDef?.type === BOOLEAN) {
+                            if (!isFieldTypeOk(value, fieldDef)) {
+                                setFileWarningMessage(
+                                    intl.formatMessage(
+                                        { id: 'WrongBooleanValueWarning' },
+                                        { field: intl.formatMessage({ id: key }) }
+                                    )
+                                );
+                            }
+                            return false; // keep looking, a boolean never raises an error
+                        }
                         // check required fields are defined
                         if (fieldDef !== undefined && fieldDef.required && (value === undefined || value === null)) {
                             requiredFieldNameInError = key;
@@ -212,7 +227,7 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
                 });
             }
         },
-        [csvFields, equipmentType, intl, setError, snackWarning]
+        [csvFields, equipmentType, intl, setError, setFileWarningMessage, snackWarning]
     );
 
     const handleTabularModificationParsingError = useCallback(
@@ -225,6 +240,19 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
             if (
                 results.data.flatMap(Object.entries).some(([key, value]) => {
                     const fieldDef = csvFields.find((field) => field.id === key);
+                    // boolean values are never blocking: an invalid one is silently replaced by
+                    // false (see sanitizeRowValue), we only warn the user it was replaced.
+                    if (fieldDef?.type === BOOLEAN) {
+                        if (!isFieldTypeOk(value, fieldDef)) {
+                            setFileWarningMessage(
+                                intl.formatMessage(
+                                    { id: 'WrongBooleanValueWarning' },
+                                    { field: intl.formatMessage({ id: key }) }
+                                )
+                            );
+                        }
+                        return false; // keep looking, a boolean never raises an error
+                    }
                     // check the field types
                     if (!isFieldTypeOk(value, fieldDef)) {
                         fieldTypeInError = key;
@@ -257,7 +285,7 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
                 snackWarning({ messageId: 'TabularModificationShuntWarning' });
             }
         },
-        [equipmentType, csvFields, setError, intl, snackWarning]
+        [equipmentType, csvFields, setError, intl, setFileWarningMessage, snackWarning]
     );
 
     const selectedProperties = useMemo((): string[] => {
@@ -333,18 +361,36 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
     const getDataFromCsvFile = useCallback(
         (results: Papa.ParseResult<Record<string, unknown>>, file: File) => {
             clearErrors(MODIFICATIONS_TABLE);
+            setFileWarningMessage(undefined);
             if (dialogMode === TabularModificationType.CREATION) {
                 handleTabularCreationParsingError(results);
             } else {
                 handleTabularModificationParsingError(results);
             }
             setValue(CSV_FILENAME, file.name);
-            return results.data.map((row) => ({
-                [FieldConstants.AG_GRID_ROW_UUID]: uuid4(),
-                ...row,
-            }));
+            // sanitize each cell: drop wrong-format values (kept out of the table) and default
+            // mandatory boolean checkboxes to false, so invalid data is never injected.
+            return results.data.map((row) => {
+                const sanitizedRow: Record<string, unknown> = {
+                    [FieldConstants.AG_GRID_ROW_UUID]: uuid4(),
+                };
+                Object.entries(row).forEach(([key, value]) => {
+                    sanitizedRow[key] = sanitizeRowValue(
+                        value,
+                        csvFields.find((field) => field.id === key)
+                    );
+                });
+                return sanitizedRow;
+            });
         },
-        [clearErrors, dialogMode, handleTabularCreationParsingError, handleTabularModificationParsingError, setValue]
+        [
+            clearErrors,
+            csvFields,
+            dialogMode,
+            handleTabularCreationParsingError,
+            handleTabularModificationParsingError,
+            setValue,
+        ]
     );
 
     useEffect(() => {
@@ -374,6 +420,7 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
         setValue(TABULAR_PROPERTIES, []);
         setSelectedFile(undefined);
         setFileErrorMessage(undefined);
+        setFileWarningMessage(undefined);
     }, [clearErrors, setValue]);
 
     const equipmentTypeField = (
@@ -516,6 +563,11 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
             {fileErrorMessage && (
                 <Grid>
                     <Alert severity="error">{fileErrorMessage}</Alert>
+                </Grid>
+            )}
+            {fileWarningMessage && (
+                <Grid>
+                    <Alert severity="warning">{fileWarningMessage}</Alert>
                 </Grid>
             )}
             {equipmentType && (

--- a/src/components/dialogs/network-modifications/tabular/tabular-form.tsx
+++ b/src/components/dialogs/network-modifications/tabular/tabular-form.tsx
@@ -118,6 +118,24 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
         [language]
     );
 
+    // Boolean values never raise a blocking error: an invalid one is silently replaced by false
+    // (see sanitizeRowValue). When the field is a boolean we only warn the user it was replaced and
+    // return true to tell the caller to skip the regular error checks for this cell.
+    const handleBooleanValue = useCallback(
+        (key: string, value: unknown, fieldDef: TabularField | undefined): boolean => {
+            if (fieldDef?.type !== BOOLEAN) {
+                return false;
+            }
+            if (!isFieldTypeOk(value, fieldDef)) {
+                setFileWarningMessage(
+                    intl.formatMessage({ id: 'WrongBooleanValueWarning' }, { field: intl.formatMessage({ id: key }) })
+                );
+            }
+            return true;
+        },
+        [intl]
+    );
+
     const handleTabularCreationParsingError = useCallback(
         (results: Papa.ParseResult<Record<string, unknown>>) => {
             let requiredFieldNameInError: string = '';
@@ -139,18 +157,9 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
                     )
                     .some(([result, key, value]) => {
                         const fieldDef = csvFields.find((field) => field.id === key);
-                        // boolean values are never blocking: an invalid one is silently replaced by
-                        // false (see sanitizeRowValue), we only warn the user it was replaced.
-                        if (fieldDef?.type === BOOLEAN) {
-                            if (!isFieldTypeOk(value, fieldDef)) {
-                                setFileWarningMessage(
-                                    intl.formatMessage(
-                                        { id: 'WrongBooleanValueWarning' },
-                                        { field: intl.formatMessage({ id: key }) }
-                                    )
-                                );
-                            }
-                            return false; // keep looking, a boolean never raises an error
+                        // boolean fields never raise a blocking error (see handleBooleanValue)
+                        if (handleBooleanValue(key, value, fieldDef)) {
+                            return false; // keep looking
                         }
                         // check required fields are defined
                         if (fieldDef !== undefined && fieldDef.required && (value === undefined || value === null)) {
@@ -227,7 +236,7 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
                 });
             }
         },
-        [csvFields, equipmentType, intl, setError, setFileWarningMessage, snackWarning]
+        [csvFields, equipmentType, handleBooleanValue, intl, setError, snackWarning]
     );
 
     const handleTabularModificationParsingError = useCallback(
@@ -240,18 +249,9 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
             if (
                 results.data.flatMap(Object.entries).some(([key, value]) => {
                     const fieldDef = csvFields.find((field) => field.id === key);
-                    // boolean values are never blocking: an invalid one is silently replaced by
-                    // false (see sanitizeRowValue), we only warn the user it was replaced.
-                    if (fieldDef?.type === BOOLEAN) {
-                        if (!isFieldTypeOk(value, fieldDef)) {
-                            setFileWarningMessage(
-                                intl.formatMessage(
-                                    { id: 'WrongBooleanValueWarning' },
-                                    { field: intl.formatMessage({ id: key }) }
-                                )
-                            );
-                        }
-                        return false; // keep looking, a boolean never raises an error
+                    // boolean fields never raise a blocking error (see handleBooleanValue)
+                    if (handleBooleanValue(key, value, fieldDef)) {
+                        return false; // keep looking
                     }
                     // check the field types
                     if (!isFieldTypeOk(value, fieldDef)) {
@@ -285,7 +285,7 @@ export function TabularForm({ dataFetching, dialogMode }: Readonly<TabularFormPr
                 snackWarning({ messageId: 'TabularModificationShuntWarning' });
             }
         },
-        [equipmentType, csvFields, setError, intl, setFileWarningMessage, snackWarning]
+        [equipmentType, csvFields, handleBooleanValue, setError, intl, snackWarning]
     );
 
     const selectedProperties = useMemo((): string[] => {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1189,6 +1189,7 @@
     "DependantFieldMissing": "\"{requiredField}\" is required if the following field is set : \"{dependantField}\"",
     "WrongFieldType": "\"{field}\" should be of type {type}",
     "WrongEnumValue": "At least one value is unexpected for field : \"{field}\", expected values : {expectedValues}",
+    "WrongBooleanValueWarning": "At least one invalid value for boolean field : \"{field}\" was automatically replaced by false.",
     "fieldType.boolean": "boolean (true/false)",
     "fieldType.number": "numerical",
     "TieLines": "Tie lines",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1187,6 +1187,7 @@
     "DependantFieldMissing": "Le champ \"{requiredField}\" est requis si le champ suivant est défini : \"{dependantField}\"",
     "WrongFieldType": "\"{field}\" doit être de type {type}",
     "WrongEnumValue": "Au moins une valeur est inattendue pour le champ : \"{field}\", valeurs attendues : {expectedValues}",
+    "WrongBooleanValueWarning": "Au moins une valeur invalide pour le champ booléen : \"{field}\" a été automatiquement remplacée par false.",
     "fieldType.boolean": "booléen (true/false)",
     "fieldType.number": "numérique",
     "TieLines": "Interconnexions",


### PR DESCRIPTION
Tabular create/modify dialogs only validated cell types at CSV import time (via `setError` on the table field). Since the submit button is disabled while any error is present and nothing cleared that error on edit, an invalid import left the dialog permanently blocked — there was no way to correct a value and validate again.

Changes:
- Sanitize imported values: wrong-format cells are dropped (replaced by `null`, kept out of the table) instead of being injected raw.
- Mandatory boolean (checkbox) columns default to `false` when empty/invalid, since an empty checkbox cannot be distinguished from `false`.
- Invalid boolean values are no longer blocking errors: they are replaced by `false` and only surface a warning, displayed below the error alert, indicating the values were replaced automatically.

Relies on the companion change in commons-ui (clearing the table field error on cell edit) to re-enable the submit button once the user edits a cell.

`limit-sets` is intentionally left out (its cells are read-only).

Also bump commons-ui to 236