### PR TITLE
fix: display state estimation data when diverged

### DIFF
--- a/src/components/results/stateestimation/state-estimation-quality-result.tsx
+++ b/src/components/results/stateestimation/state-estimation-quality-result.tsx
@@ -24,7 +24,6 @@ import { RenderTableAndExportCsv } from '../../utils/renderTable-ExportCsv';
 import { AgGridReact } from 'ag-grid-react';
 import { StateEstimationResultProps } from './state-estimation-result.type';
 import { TableType } from 'types/custom-aggrid-types';
-import { getRows } from './state-estimation-result-utils';
 
 export const StateEstimationQualityResult: FunctionComponent<StateEstimationResultProps> = ({
     result,
@@ -89,10 +88,10 @@ export const StateEstimationQualityResult: FunctionComponent<StateEstimationResu
             stateEstimationStatus,
             !isLoadingResult
         );
-        const rowsToShow = getRows(
-            tableName === 'qualityCriterionResults' ? result.qualityCriterionResults : result.qualityPerRegionResults,
-            stateEstimationStatus
-        );
+        const rowsToShow =
+            (tableName === 'qualityCriterionResults'
+                ? result.qualityCriterionResults
+                : result.qualityPerRegionResults) ?? [];
 
         return (
             <>

--- a/src/components/results/stateestimation/state-estimation-quality-result.tsx
+++ b/src/components/results/stateestimation/state-estimation-quality-result.tsx
@@ -14,7 +14,7 @@ import { RowClassParams } from 'ag-grid-community';
 import { ComputingType, DefaultCellRenderer } from '@gridsuite/commons-ui';
 import { AppState } from '../../../redux/reducer.type';
 
-import { getNoRowsMessage, getRows, useIntlResultStatusMessages } from '../../utils/aggrid-rows-handler';
+import { getNoRowsMessage, useIntlResultStatusMessages } from '../../utils/aggrid-rows-handler';
 
 import LinearProgress from '@mui/material/LinearProgress';
 import { RunningStatus } from '../../utils/running-status';
@@ -24,6 +24,7 @@ import { RenderTableAndExportCsv } from '../../utils/renderTable-ExportCsv';
 import { AgGridReact } from 'ag-grid-react';
 import { StateEstimationResultProps } from './state-estimation-result.type';
 import { TableType } from 'types/custom-aggrid-types';
+import { getRows } from './state-estimation-result-utils';
 
 export const StateEstimationQualityResult: FunctionComponent<StateEstimationResultProps> = ({
     result,

--- a/src/components/results/stateestimation/state-estimation-result-tab.tsx
+++ b/src/components/results/stateestimation/state-estimation-result-tab.tsx
@@ -82,7 +82,10 @@ export const StateEstimationResultTab: FunctionComponent<StateEstimationTabProps
     };
 
     const result = useMemo(() => {
-        if (stateEstimationStatus !== RunningStatus.SUCCEED || !stateEstimationResult) {
+        if (
+            !(stateEstimationStatus === RunningStatus.SUCCEED || stateEstimationStatus === RunningStatus.FAILED) ||
+            !stateEstimationResult
+        ) {
             return {};
         }
         return {

--- a/src/components/results/stateestimation/state-estimation-result-tab.tsx
+++ b/src/components/results/stateestimation/state-estimation-result-tab.tsx
@@ -82,10 +82,9 @@ export const StateEstimationResultTab: FunctionComponent<StateEstimationTabProps
     };
 
     const result = useMemo(() => {
-        if (
-            !(stateEstimationStatus === RunningStatus.SUCCEED || stateEstimationStatus === RunningStatus.FAILED) ||
-            !stateEstimationResult
-        ) {
+        const isProcessing =
+            stateEstimationStatus !== RunningStatus.SUCCEED && stateEstimationStatus !== RunningStatus.FAILED;
+        if (isProcessing || !stateEstimationResult) {
             return {};
         }
         return {

--- a/src/components/results/stateestimation/state-estimation-result-utils.ts
+++ b/src/components/results/stateestimation/state-estimation-result-utils.ts
@@ -8,7 +8,6 @@
 import { IntlShape } from 'react-intl';
 import { ColDef } from 'ag-grid-community';
 import { makeAgGridCustomHeaderColumn } from 'components/custom-aggrid/utils/custom-aggrid-header-utils';
-import RunningStatus from '../../utils/running-status';
 
 export const stateEstimationQualityCriterionColumnsDefinition = (intl: IntlShape): ColDef[] => {
     return [
@@ -65,7 +64,3 @@ export const stateEstimationQualityPerRegionColumnsDefinition = (intl: IntlShape
         }),
     ];
 };
-
-export function getRows(rows: any[] | undefined, status: string): any[] {
-    return (status === RunningStatus.SUCCEED || status === RunningStatus.FAILED) && rows ? rows : [];
-}

--- a/src/components/results/stateestimation/state-estimation-result-utils.ts
+++ b/src/components/results/stateestimation/state-estimation-result-utils.ts
@@ -8,6 +8,7 @@
 import { IntlShape } from 'react-intl';
 import { ColDef } from 'ag-grid-community';
 import { makeAgGridCustomHeaderColumn } from 'components/custom-aggrid/utils/custom-aggrid-header-utils';
+import RunningStatus from '../../utils/running-status';
 
 export const stateEstimationQualityCriterionColumnsDefinition = (intl: IntlShape): ColDef[] => {
     return [
@@ -64,3 +65,7 @@ export const stateEstimationQualityPerRegionColumnsDefinition = (intl: IntlShape
         }),
     ];
 };
+
+export function getRows(rows: any[] | undefined, status: string): any[] {
+    return (status === RunningStatus.SUCCEED || status === RunningStatus.FAILED) && rows ? rows : [];
+}


### PR DESCRIPTION
Fix bug : display state estimation data when diverged in tabs Status, Criterion quality and Quality per region

