### PR TITLE
Fix process is not defined crash from react-draggable following dependency upgrade

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,11 @@ const serverSettings: CommonServerOptions = {
 };
 
 export default defineConfig((_config) => ({
+    define: {
+        // Work around react-draggable accessing process.env in browser bundles:
+        // https://github.com/react-grid-layout/react-draggable/issues/806
+        'process.env.DRAGGABLE_DEBUG': false,
+    },
     plugins: [
         react(),
         process.env.VITE_CHECKER_ENABLED === 'true' &&


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
Prevent the `process is not defined` crash in `react-draggable` by inlining `process.env.DRAGGABLE_DEBUG` to `false` in the Vite build.   
Crash happened when moving panels around in the gridstudy-app.
Related issue: https://github.com/react-grid-layout/react-draggable/issues/806 (still open).