### PR TITLE
Work around for React useEffectEvent + memo() stale closure bug in NAD content

### DIFF
--- a/src/components/grid-layout/cards/diagrams/networkAreaDiagram/network-area-diagram-content.tsx
+++ b/src/components/grid-layout/cards/diagrams/networkAreaDiagram/network-area-diagram-content.tsx
@@ -138,6 +138,8 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
         studyUuid,
         currentNode,
         currentRootNetworkUuid,
+        onMoveNode,
+        onMoveTextNode,
     };
     const latestRef = useRef(latestValues);
     latestRef.current = latestValues;
@@ -397,12 +399,12 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
     );
 
     const handleMoveNode = useEffectEvent((equipmentId: string, nodeId: string, x: number, y: number) => {
-        onMoveNode(equipmentId, x, y);
+        latestRef.current.onMoveNode(equipmentId, x, y);
     });
 
     const handleMoveTextnode = useEffectEvent(
         (equipmentId: string, vlNodeId: string, textNodeId: string, shiftX: number, shiftY: number) => {
-            onMoveTextNode(equipmentId, shiftX, shiftY);
+            latestRef.current.onMoveTextNode(equipmentId, shiftX, shiftY);
         }
     );
 

--- a/src/components/grid-layout/cards/diagrams/networkAreaDiagram/network-area-diagram-content.tsx
+++ b/src/components/grid-layout/cards/diagrams/networkAreaDiagram/network-area-diagram-content.tsx
@@ -126,9 +126,21 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
     const [isEditNadMode, setIsEditNadMode] = useState<boolean>(false);
     const workspaceId = useSelector(selectActiveWorkspaceId);
 
-    // ref to keep useLayoutEffect and callbacks stable
-    const isEditNadModeRef = useRef(isEditNadMode);
-    isEditNadModeRef.current = isEditNadMode;
+    // Workaround for https://github.com/react/react/issues/35187 and https://github.com/react/react/issues/35034:
+    // useEffectEvent retains the first render value when is used inside a component wrapped in memo()
+    // => Read values through this ref (updated every render) instead to avoid stale values in useEffectEvent
+    // => This workaround should be removed once the issue is fixed
+    const latestValues = {
+        isEditNadMode,
+        loadingState,
+        onVoltageLevelClick,
+        additionalMetadata,
+        studyUuid,
+        currentNode,
+        currentRootNetworkUuid,
+    };
+    const latestRef = useRef(latestValues);
+    latestRef.current = latestValues;
 
     const initialLocalStorageViewBox = useRef(
         (() => {
@@ -162,7 +174,7 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
     const handleToggleHover: OnToggleNadHoverCallbackType = useEffectEvent(
         (shouldDisplay: boolean, mousePosition: Point | null, equipmentId: string, equipmentType: string) => {
             // Do not show the hover in edit mode
-            if (isEditNadModeRef.current) {
+            if (latestRef.current.isEditNadMode) {
                 return;
             }
             if (mousePosition) {
@@ -187,13 +199,13 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
     );
 
     const handleNodeLeftClick: OnSelectNodeCallbackType = useEffectEvent((equipmentId, nodeId, mousePosition) => {
-        if (mousePosition && !loadingState) {
-            if (isEditNadModeRef.current) {
+        if (mousePosition && !latestRef.current.loadingState) {
+            if (latestRef.current.isEditNadMode) {
                 setSelectedVoltageLevelId(equipmentId);
                 setShouldDisplayMenu(true);
                 setMenuAnchorPosition(mousePosition ? { mouseX: mousePosition.x, mouseY: mousePosition.y } : null);
             } else {
-                onVoltageLevelClick(equipmentId);
+                latestRef.current.onVoltageLevelClick(equipmentId);
             }
         }
     });
@@ -273,14 +285,14 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
 
     const showEquipmentMenu = useEffectEvent(
         (svgId: string, equipmentId: string, equipmentType: string, mousePosition: Point) => {
-            if (isEditNadModeRef.current || !equipmentsWithContextualMenu.includes(equipmentType)) {
+            if (latestRef.current.isEditNadMode || !equipmentsWithContextualMenu.includes(equipmentType)) {
                 return;
             }
 
             const openMenu = (equipmentType: EquipmentType, equipmentSubtype: ExtendedEquipmentType | null = null) => {
                 const equipment: Partial<MapEquipment> = { id: equipmentId };
                 if (equipmentType === EquipmentType.VOLTAGE_LEVEL) {
-                    const vlSubstationId = additionalMetadata?.voltageLevels.find(
+                    const vlSubstationId = latestRef.current.additionalMetadata?.voltageLevels.find(
                         (vl) => vl.id === equipmentId
                     )?.substationId;
                     if (vlSubstationId) {
@@ -301,9 +313,9 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
                 // need a query to know the HVDC converters type (LCC vs VSC)
                 // this section should be removed when the NAD will provide this information in the SVG metadata
                 fetchNetworkElementInfos(
-                    studyUuid,
-                    currentNode?.id,
-                    currentRootNetworkUuid,
+                    latestRef.current.studyUuid,
+                    latestRef.current.currentNode?.id,
+                    latestRef.current.currentRootNetworkUuid,
                     EquipmentType.HVDC_LINE,
                     EQUIPMENT_INFOS_TYPES.MAP.type,
                     equipmentId,
@@ -474,7 +486,7 @@ const NetworkAreaDiagramContent = memo(function NetworkAreaDiagramContent(props:
                 minHeight: MIN_HEIGHT,
                 maxWidth: MAX_WIDTH_NETWORK_AREA_DIAGRAM,
                 maxHeight: MAX_HEIGHT_NETWORK_AREA_DIAGRAM,
-                enableDragInteraction: isEditNadModeRef.current,
+                enableDragInteraction: latestRef.current.isEditNadMode,
                 enableLevelOfDetail: true,
                 zoomLevels: NAD_ZOOM_LEVELS,
                 addButtons: false,


### PR DESCRIPTION
Workaround for https://github.com/react/react/issues/35187 and https://github.com/react/react/issues/35034:
useEffectEvent retains the first render value when is used inside a component wrapped in memo()
This workaround should be removed once the issue is fixed