### PR TITLE
[FIX] Estim Params disabled while service UP

### DIFF
--- a/src/components/parameters-tabs.tsx
+++ b/src/components/parameters-tabs.tsx
@@ -550,7 +550,7 @@ const ParametersTabs: FunctionComponent = () => {
                       {
                           value: TAB_VALUES.stateEstimationTabValue,
                           labelId: 'StateEstimation',
-                          disabled: stateEstimationAvailability === OptionalServicesStatus.Up,
+                          disabled: stateEstimationAvailability !== OptionalServicesStatus.Up,
                       },
                   ]
                 : []),


### PR DESCRIPTION
## PR Summary
Regression from https://github.com/gridsuite/gridstudy-app/pull/4040



