### PR TITLE
Warn instead of crash when network contains voltage level without substation

### DIFF
--- a/src/components/network/network-map-panel.tsx
+++ b/src/components/network/network-map-panel.tsx
@@ -172,7 +172,7 @@ export const NetworkMapPanel = memo(function NetworkMapPanel({
     const [isInitialized, setIsInitialized] = useState(false);
     const mapBoxToken = useMapBoxToken();
 
-    const { snackError } = useSnackMessage();
+    const { snackError, snackWarning } = useSnackMessage();
 
     const [filteredNominalVoltages, setFilteredNominalVoltages] = useState<number[]>();
     const [geoData, setGeoData] = useState<GeoData>();
@@ -180,8 +180,23 @@ export const NetworkMapPanel = memo(function NetworkMapPanel({
 
     const basicDataReady = mapEquipments && geoData;
 
+    const voltageLevelIdsWithoutSubstation = useMemo(() => {
+        if (!mapEquipments) {
+            return [];
+        }
+
+        const voltageLevelIds = new Set([
+            ...mapEquipments.getLines().flatMap((line) => [line.voltageLevelId1, line.voltageLevelId2]),
+            ...mapEquipments.getTieLines().flatMap((line) => [line.voltageLevelId1, line.voltageLevelId2]),
+            ...mapEquipments.getHvdcLines().flatMap((line) => [line.voltageLevelId1, line.voltageLevelId2]),
+        ]);
+
+        return Array.from(voltageLevelIds).filter((voltageLevelId) => !mapEquipments.getVoltageLevel(voltageLevelId));
+    }, [mapEquipments]);
+
     const lineFullPathRef = useRef<boolean>(null);
     const [isDialogSearchOpen, setIsDialogSearchOpen] = useState(false);
+    const voltageLevelWarningShownRef = useRef(false);
 
     const { getBaseVoltageInterval } = useBaseVoltages();
 
@@ -209,6 +224,25 @@ export const NetworkMapPanel = memo(function NetworkMapPanel({
     const [position, setPosition] = useState([-1, -1]);
     const currentNodeRef = useRef<CurrentTreeNode | null>(null);
     const currentRootNetworkUuidRef = useRef<UUID | null>(null);
+
+    useEffect(() => {
+        if (!isInitialized) {
+            voltageLevelWarningShownRef.current = false;
+        } else if (voltageLevelIdsWithoutSubstation.length > 0 && !voltageLevelWarningShownRef.current) {
+            const voltageLevelIds =
+                voltageLevelIdsWithoutSubstation.length > 3
+                    ? voltageLevelIdsWithoutSubstation.slice(0, 3).join(', ') + ', ...'
+                    : voltageLevelIdsWithoutSubstation.join(', ');
+            snackWarning({
+                messageId: 'networkMapVoltageLevelsWithoutSubstation',
+                messageValues: {
+                    voltageLevelCount: voltageLevelIdsWithoutSubstation.length,
+                    voltageLevelIds: voltageLevelIds,
+                },
+            });
+            voltageLevelWarningShownRef.current = true;
+        }
+    }, [isInitialized, snackWarning, voltageLevelIdsWithoutSubstation]);
 
     const [updatedLines, setUpdatedLines] = useState<MapLineWithType[]>([]);
     const [updatedTieLines, setUpdatedTieLines] = useState<MapTieLineWithType[]>([]);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -68,6 +68,7 @@
     "svgNotFound": "Diagram has not been found: {error}; {svgUrl}",
     "networkLoadingFail": "Network of study with id \"{studyUuid}\" couldn't be loaded",
     "geoDataLoadingFail": "An error occurred while loading geographical data.",
+    "networkMapVoltageLevelsWithoutSubstation": "{voltageLevelCount} voltage levels are not attached to a substation and therefore are not displayed. Examples: {voltageLevelIds}",
 
     "parameters": "Parameters",
     "close": "Close",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -68,6 +68,7 @@
     "svgNotFound": "L'image poste n'a pas été trouvée : {error}; {svgUrl}",
     "networkLoadingFail": "Le réseau de l'étude avec l'identifiant \"{studyUuid}\" n'a pas pu être chargé",
     "geoDataLoadingFail": "Erreur lors du chargement des données géographiques.",
+    "networkMapVoltageLevelsWithoutSubstation": "{voltageLevelCount} niveaux de tension ne sont pas rattachés à un site et ne sont donc pas affichés. Exemples : {voltageLevelIds}",
 
     "parameters": "Paramètres",
     "close": "Fermer",


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
Detect voltage levels referenced by lines, tie lines, or HVDC lines that are missing from the map equipment index because they are not attached to a substation. After map initialization, display a warning snackbar explaining that these voltage levels are not displayed.
