### PR TITLE
fix(TwoWindingsTransformerCreation): empty temporary limit value wrongly reported as mandatory

### DIFF
--- a/src/components/dialogs/network-modifications/two-windings-transformer/creation/two-windings-transformer-creation-dialog.tsx
+++ b/src/components/dialogs/network-modifications/two-windings-transformer/creation/two-windings-transformer-creation-dialog.tsx
@@ -272,8 +272,8 @@ const TwoWindingsTransformerCreationDialog = ({
                     temporaryLimits:
                         currentLimits?.temporaryLimits?.map((tl) => ({
                             name: tl.name ?? '',
-                            value: (tl.value ?? '') as unknown as number,
-                            acceptableDuration: (tl.acceptableDuration ?? '') as unknown as number,
+                            value: tl.value,
+                            acceptableDuration: tl.acceptableDuration,
                         })) ?? [],
                 },
             }));


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
Fix reported from https://github.com/gridsuite/commons-ui/pull/1306

This is a report from commons-ui because the file has been moved from study to common in the mean time.


