### PR TITLE
Share a composite modification nested in another composite

### DIFF
--- a/src/components/graph/menus/network-modifications/network-modification-node-editor.tsx
+++ b/src/components/graph/menus/network-modifications/network-modification-node-editor.tsx
@@ -8,8 +8,6 @@
 import {
     ArrowsInputIcon,
     ComposedModificationMetadata,
-    ElementSaveDialog,
-    ElementType,
     EquipmentType,
     ErrorMessage,
     fetchNetworkModification,
@@ -109,6 +107,7 @@ import ModificationByFormulaDialog from '../../../dialogs/network-modifications/
 import ByFilterDeletionDialog from '../../../dialogs/network-modifications/by-filter/by-filter-deletion/by-filter-deletion-dialog';
 import { LccCreationDialog } from '../../../dialogs/network-modifications/hvdc-line/lcc/creation/lcc-creation-dialog';
 import { styles } from './network-modification-node-editor-utils';
+import SaveNetworkModificationsDialog from './save-network-modifications-dialog';
 import {
     CommonStudyEventData,
     isModificationsDeleteFinishedNotification,
@@ -1080,14 +1079,6 @@ const NetworkModificationNodeEditor = () => {
             ? (JSON.parse(selectedNetworkModifications[0]?.messageValues)?.name ?? null)
             : null;
 
-    // Sharing moves the selected composite itself into gridexplore : it needs exactly one composite, and an
-    // already shared one (a reference) cannot be shared again. Only a composite of the node itself can be shared,
-    // not one nested in another composite, so the third condition: the modifications list holds the modifications of the node only
-    const isSharingAvailable =
-        selectedNetworkModifications.length === 1 &&
-        selectedNetworkModifications[0].type === ModificationType.COMPOSITE_MODIFICATION &&
-        modifications.some((modification) => modification.uuid === selectedNetworkModifications[0].uuid);
-
     const renderNetworkModificationsTable = () => {
         if (isRootNode) {
             return (
@@ -1138,22 +1129,15 @@ const NetworkModificationNodeEditor = () => {
     const renderCreateCompositeNetworkModificationsDialog = () => {
         return (
             studyUuid && (
-                <ElementSaveDialog
+                <SaveNetworkModificationsDialog
                     open={createCompositeModificationDialogOpen}
+                    onClose={() => setCreateCompositeModificationDialogOpen(false)}
+                    studyUuid={studyUuid}
+                    selectedModifications={selectedNetworkModifications}
+                    defaultName={defaultSaveModificationName}
                     onSave={doCreateCompositeModificationsElements}
                     onSaveShared={doShareCompositeModificationElement}
-                    createSharedDisabled={!isSharingAvailable}
-                    OnUpdate={doUpdateCompositeModificationsElements}
-                    onClose={() => setCreateCompositeModificationDialogOpen(false)}
-                    type={ElementType.MODIFICATION}
-                    titleId="CreateCompositeModification"
-                    prefixIdForGeneratedName="GeneratedModification"
-                    defaultName={defaultSaveModificationName}
-                    studyUuid={studyUuid}
-                    selectorTitleId="SelectCompositeModificationTitle"
-                    createLabelId="CreateCompositeModificationLabel"
-                    createSharedLabelId="ShareCompositeModificationLabel"
-                    updateLabelId="UpdateCompositeModificationLabel"
+                    onUpdate={doUpdateCompositeModificationsElements}
                 />
             )
         );

--- a/src/components/graph/menus/network-modifications/save-network-modifications-dialog.tsx
+++ b/src/components/graph/menus/network-modifications/save-network-modifications-dialog.tsx
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    ComposedModificationMetadata,
+    ElementSaveDialog,
+    ElementType,
+    type IElementCreationDialog,
+    type IElementUpdateDialog,
+    ModificationType,
+    PARAM_DEVELOPER_MODE,
+} from '@gridsuite/commons-ui';
+import type { UUID } from 'node:crypto';
+import { useEffect, useState } from 'react';
+import { useParameterState } from 'components/dialogs/parameters/use-parameters-state';
+import { containsSharedModification } from '../../../../services/study/network-modifications';
+
+export interface SaveNetworkModificationsDialogProps {
+    open: boolean;
+    onClose: () => void;
+    studyUuid: UUID;
+    selectedModifications: ComposedModificationMetadata[];
+    defaultName: string | null;
+    onSave: (data: IElementCreationDialog) => void;
+    onSaveShared: (data: IElementCreationDialog) => void;
+    onUpdate: (data: IElementUpdateDialog) => void;
+}
+
+export default function SaveNetworkModificationsDialog({
+    open,
+    onClose,
+    studyUuid,
+    selectedModifications,
+    defaultName,
+    onSave,
+    onSaveShared,
+    onUpdate,
+}: Readonly<SaveNetworkModificationsDialogProps>) {
+    const [isDeveloperMode] = useParameterState(PARAM_DEVELOPER_MODE);
+    const [selectedCompositeContainsShared, setSelectedCompositeContainsShared] = useState<boolean>();
+
+    // Sharing moves the selected composite itself into gridexplore : it needs exactly one composite, and an already
+    // shared one (a reference) cannot be shared again.
+    const selectedComposite =
+        selectedModifications.length === 1 && selectedModifications[0].type === ModificationType.COMPOSITE_MODIFICATION
+            ? selectedModifications[0]
+            : undefined;
+
+    // A composite nested in another composite of the node can be shared, but not one contained by an already shared
+    // composite.
+    const isSelectedCompositeShareable = selectedComposite !== undefined && !selectedComposite.childFromShared;
+
+    // only the server can tell whether the composite contains a shared modification : the table only loads its
+    // content as it is unfolded.
+    useEffect(() => {
+        setSelectedCompositeContainsShared(undefined);
+        if (!open || !isDeveloperMode || !isSelectedCompositeShareable) {
+            return;
+        }
+        let active = true; // to manage race condition
+        containsSharedModification(selectedComposite.uuid)
+            .then((containsShared) => {
+                if (active) {
+                    setSelectedCompositeContainsShared(containsShared);
+                }
+            })
+            .catch((error) => {
+                console.error(
+                    `Failed to know whether composite ${selectedComposite.uuid} contains a shared modification`,
+                    error
+                );
+            });
+        return () => {
+            active = false;
+        };
+    }, [open, isDeveloperMode, isSelectedCompositeShareable, selectedComposite]);
+
+    const isSharingAvailable =
+        isDeveloperMode && isSelectedCompositeShareable && selectedCompositeContainsShared === false;
+
+    return (
+        <ElementSaveDialog
+            open={open}
+            onSave={onSave}
+            onSaveShared={onSaveShared}
+            createSharedDisabled={!isSharingAvailable}
+            OnUpdate={onUpdate}
+            onClose={onClose}
+            type={ElementType.MODIFICATION}
+            titleId="CreateCompositeModification"
+            prefixIdForGeneratedName="GeneratedModification"
+            defaultName={defaultName}
+            studyUuid={studyUuid}
+            selectorTitleId="SelectCompositeModificationTitle"
+            createLabelId="CreateCompositeModificationLabel"
+            createSharedLabelId="ShareCompositeModificationLabel"
+            updateLabelId="UpdateCompositeModificationLabel"
+        />
+    );
+}

--- a/src/services/study/network-modifications.ts
+++ b/src/services/study/network-modifications.ts
@@ -1591,6 +1591,14 @@ export function shareCompositeModification(
     return backendFetch(url, { method: 'POST' });
 }
 
+export function containsSharedModification(compositeModificationUuid: UUID): Promise<boolean> {
+    const url = `${PREFIX_STUDY_QUERIES}/v1/network-composite-modifications/${safeEncodeURIComponent(
+        compositeModificationUuid
+    )}/contains-shared-modification`;
+    console.debug(url);
+    return backendFetchJson(url);
+}
+
 export function getNetworkModificationsFromComposite(
     compositeModificationUuids: string[],
     onlyMetadata: boolean = true


### PR DESCRIPTION
Follow-up of #4157.

The "New (shared)" option of the dialog saving modifications into GridExplore is now only enabled in developer mode — it stays visible but greyed out otherwise.

A composite modification nested in another composite of the node can now be shared, as long as it is not contained by an already shared composite. The option is also greyed out when the selected composite contains a shared modification, at any depth: since the table only loads the content of a composite as it is unfolded, the server is asked, once the dialog is open.

The saving logic moves out of the node editor into a dedicated `SaveNetworkModificationsDialog` wrapping `ElementSaveDialog`. A single server call there both warns that shared modifications are saved as a copy and greys out the sharing.

Requires gridsuite/study-server#1089 and gridsuite/commons-ui#1336.
